### PR TITLE
feat: 맵 등록 기능 및 공통 헤더 컴포넌트 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ dist-ssr
 .env.*
 !.env.example
 
+# MCP config (contains access tokens)
+.mcp.json
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,0 +1,224 @@
+<template>
+  <header class="app-header">
+    <!-- 좌: 브랜드 -->
+    <RouterLink to="/" class="header-brand">
+      <svg width="28" height="28" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="hIconGrad" x1="0" y1="0" x2="44" y2="44" gradientUnits="userSpaceOnUse">
+            <stop stop-color="#aa3bff"/>
+            <stop offset="1" stop-color="#5865f2"/>
+          </linearGradient>
+        </defs>
+        <rect width="44" height="44" rx="12" fill="url(#hIconGrad)"/>
+        <rect x="0.5" y="0.5" width="43" height="43" rx="11.5" stroke="white" stroke-opacity="0.15"/>
+        <path d="M22 9L31 25H13L22 9Z" fill="white" opacity="0.95"/>
+        <path d="M22 18L27.5 27H16.5L22 18Z" fill="white" opacity="0.3"/>
+        <rect x="11" y="30" width="22" height="2" rx="1" fill="white" opacity="0.4"/>
+      </svg>
+      <span class="brand-word"><span class="brand-em">바닥</span>티어</span>
+    </RouterLink>
+
+    <!-- 중: 네비게이션 (확장 가능) -->
+    <nav class="header-nav">
+      <RouterLink
+        v-for="item in navItems"
+        :key="item.to"
+        :to="item.to"
+        class="nav-link"
+        active-class="nav-link--active"
+      >
+        {{ item.label }}
+      </RouterLink>
+    </nav>
+
+    <!-- 우: 유저 + 액션 -->
+    <div class="header-right">
+      <!-- 유저 정보 -->
+      <div v-if="auth.user" class="user-info">
+        <img
+          v-if="avatarUrl"
+          :src="avatarUrl"
+          :alt="displayName"
+          class="user-avatar"
+          referrerpolicy="no-referrer"
+        />
+        <div v-else class="user-avatar user-avatar--fallback">
+          {{ displayName?.charAt(0) }}
+        </div>
+        <span class="user-name">{{ displayName }}</span>
+      </div>
+
+      <!-- 액션 버튼 슬롯 (페이지별로 다른 버튼 주입 가능) -->
+      <slot name="actions" />
+
+      <!-- 로그아웃 -->
+      <button class="header-btn" @click="handleLogout">로그아웃</button>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { RouterLink, useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+
+const auth = useAuthStore()
+const router = useRouter()
+
+// 추후 네비게이션 항목 여기에 추가
+const navItems = [
+  // { to: '/maps', label: '맵 목록' },
+  // { to: '/rankings', label: '랭킹' },
+]
+
+const avatarUrl = computed(() => auth.user?.user_metadata?.avatar_url as string | undefined)
+const displayName = computed(() =>
+  (auth.user?.user_metadata?.full_name
+  || auth.user?.user_metadata?.name
+  || auth.user?.email) as string | undefined
+)
+
+async function handleLogout() {
+  await auth.logout()
+  router.push({ name: 'login' })
+}
+</script>
+
+<style scoped>
+.app-header {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 0 28px;
+  height: 60px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  background: rgba(10, 11, 16, 0.85);
+  backdrop-filter: blur(16px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+/* 브랜드 */
+.header-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.brand-word {
+  font-size: 17px;
+  font-weight: 800;
+  color: rgba(255, 255, 255, 0.75);
+  font-family: system-ui, sans-serif;
+  letter-spacing: -0.01em;
+}
+
+.brand-em {
+  background: linear-gradient(135deg, #c084fc, #aa3bff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  font-weight: 900;
+}
+
+/* 네비게이션 */
+.header-nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+}
+
+.nav-link {
+  padding: 6px 12px;
+  border-radius: 7px;
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.45);
+  text-decoration: none;
+  font-family: system-ui, sans-serif;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  &--active {
+    color: #c084fc;
+    background: rgba(170, 59, 255, 0.1);
+  }
+}
+
+/* 우측 영역 */
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+/* 유저 정보 */
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px 4px 4px;
+  border-radius: 100px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.user-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+
+  &--fallback {
+    background: linear-gradient(135deg, #aa3bff, #5865f2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 700;
+    color: #fff;
+    font-family: system-ui, sans-serif;
+  }
+}
+
+.user-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.75);
+  font-family: system-ui, sans-serif;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* 버튼 공통 */
+.header-btn {
+  padding: 7px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: system-ui, sans-serif;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.75);
+  }
+}
+</style>

--- a/src/lib/maps.ts
+++ b/src/lib/maps.ts
@@ -1,0 +1,51 @@
+import { supabase } from '@/lib/supabase'
+
+export interface MapInsert {
+  name: string
+  aliases: string[]
+  width: number
+  height: number
+  player_count: number
+  tileset: string
+  imageFile: File | null
+}
+
+export async function createMap(data: MapInsert) {
+  let image_url: string | null = null
+
+  // 1. 이미지 업로드
+  if (data.imageFile) {
+    const ext = data.imageFile.name.split('.').pop()
+    const path = `${crypto.randomUUID()}.${ext}`
+
+    const { error: uploadError } = await supabase.storage
+      .from('map-images')
+      .upload(path, data.imageFile)
+
+    if (uploadError) throw uploadError
+
+    const { data: urlData } = supabase.storage
+      .from('map-images')
+      .getPublicUrl(path)
+
+    image_url = urlData.publicUrl
+  }
+
+  // 2. maps 테이블에 저장
+  const { data: map, error } = await supabase
+    .from('maps')
+    .insert({
+      name: data.name,
+      aliases: data.aliases,
+      width: data.width,
+      height: data.height,
+      player_count: data.player_count,
+      tileset: data.tileset,
+      image_url,
+    })
+    .select()
+    .single()
+
+  if (error) throw error
+  return map
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -16,6 +16,12 @@ const router = createRouter({
       component: () => import('@/views/LoginView.vue'),
     },
     {
+      path: '/maps/register',
+      name: 'map-register',
+      component: () => import('@/views/MapRegisterView.vue'),
+      meta: { requiresAuth: true },
+    },
+    {
       path: '/auth/callback',
       name: 'auth-callback',
       component: () => import('@/views/AuthCallbackView.vue'),

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,30 +1,69 @@
 <template>
   <div class="home">
-    <p>안녕하세요, {{ auth.user?.user_metadata?.full_name }}</p>
-    <button @click="logout()">로그아웃</button>
+    <AppHeader>
+      <template #actions>
+        <RouterLink to="/maps/register" class="header-btn header-btn--primary">
+          <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+            <path d="M7 2V12M2 7H12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
+          맵 등록
+        </RouterLink>
+      </template>
+    </AppHeader>
+
+    <div class="home-content">
+      <p class="welcome">준비 중인 콘텐츠입니다</p>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
-import { useAuthStore } from '@/stores/auth'
-
-const auth = useAuthStore()
-const router = useRouter()
-
-async function logout() {
-  await auth.logout()
-  router.push({ name: 'login' })
-}
+import { RouterLink } from 'vue-router'
+import AppHeader from '@/components/AppHeader.vue'
 </script>
 
 <style scoped>
 .home {
+  min-height: 100vh;
+  background: #0a0b10;
   display: flex;
   flex-direction: column;
+}
+
+.home-content {
+  flex: 1;
+  display: flex;
   align-items: center;
   justify-content: center;
-  height: 100vh;
-  gap: 1rem;
+}
+
+.welcome {
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.25);
+  font-family: system-ui, sans-serif;
+}
+
+.header-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(170, 59, 255, 0.4);
+  background: rgba(170, 59, 255, 0.12);
+  color: #c084fc;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: system-ui, sans-serif;
+  text-decoration: none;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+
+  &--primary:hover {
+    background: rgba(170, 59, 255, 0.22);
+    border-color: rgba(170, 59, 255, 0.65);
+    color: #d8a4ff;
+  }
 }
 </style>

--- a/src/views/MapRegisterView.scss
+++ b/src/views/MapRegisterView.scss
@@ -1,0 +1,517 @@
+// ── 공통 배경 (LoginView와 동일한 분위기) ─────────────────────────────────
+.map-register-page {
+  position: relative;
+  min-height: 100vh;
+  background: #0a0b10;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.orb {
+  position: fixed;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.2;
+  pointer-events: none;
+}
+
+.orb-1 {
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(circle, #aa3bff, transparent);
+  top: -120px;
+  right: -80px;
+}
+
+.orb-2 {
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, #5865f2, transparent);
+  bottom: 0;
+  left: -100px;
+}
+
+.grid-overlay {
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+  background-size: 60px 60px;
+  pointer-events: none;
+}
+
+// ── 레이아웃 ─────────────────────────────────────────────────────────────
+.page-inner {
+  position: relative;
+  max-width: 720px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 40px 24px 80px;
+  box-sizing: border-box;
+  animation: fadeUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(24px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+// ── 헤더 ─────────────────────────────────────────────────────────────────
+.page-header {
+  margin-bottom: 36px;
+}
+
+.page-title {
+  h1 {
+    font-size: 30px;
+    font-weight: 800;
+    color: #fff;
+    margin: 0 0 6px;
+    letter-spacing: -0.5px;
+    font-family: system-ui, sans-serif;
+  }
+
+  p {
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.4);
+    margin: 0;
+  }
+}
+
+// ── 폼 공통 ──────────────────────────────────────────────────────────────
+.register-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.form-section {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  padding: 24px;
+  backdrop-filter: blur(12px);
+}
+
+.section-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(170, 59, 255, 0.8);
+  margin: 0 0 20px;
+  font-family: system-ui, sans-serif;
+}
+
+// ── 이미지 업로드 ─────────────────────────────────────────────────────────
+.image-upload {
+  position: relative;
+  border: 1.5px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+  overflow: hidden;
+
+  &:hover,
+  &.drag-over {
+    border-color: rgba(170, 59, 255, 0.5);
+    background: rgba(170, 59, 255, 0.04);
+  }
+
+  &.has-image {
+    border-style: solid;
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.upload-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 32px;
+}
+
+.upload-label {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.5);
+  font-family: system-ui, sans-serif;
+}
+
+.upload-hint {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.25);
+  font-family: system-ui, sans-serif;
+}
+
+.image-preview {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  display: block;
+}
+
+.image-remove {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.6);
+  color: rgba(255, 255, 255, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover { background: rgba(204, 50, 50, 0.7); }
+}
+
+// ── 필드 ─────────────────────────────────────────────────────────────────
+.field-row {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+
+  @media (max-width: 560px) { flex-direction: column; }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+
+  &--small { flex: 0 0 auto; }
+}
+
+.field-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.05em;
+  font-family: system-ui, sans-serif;
+}
+
+.field-input {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 11px 14px;
+  font-size: 14px;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+  outline: none;
+  transition: border-color 0.2s, background 0.2s;
+  width: 100%;
+  box-sizing: border-box;
+
+  &::placeholder { color: rgba(255, 255, 255, 0.2); }
+
+  &:focus {
+    border-color: rgba(170, 59, 255, 0.5);
+    background: rgba(170, 59, 255, 0.05);
+  }
+
+  // number input 화살표 숨기기
+  &[type='number'] {
+    -moz-appearance: textfield;
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button { display: none; }
+  }
+}
+
+// ── 인원 수 선택 ──────────────────────────────────────────────────────────
+.player-selector {
+  display: flex;
+  gap: 6px;
+}
+
+.player-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: system-ui, sans-serif;
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+
+  &:hover {
+    border-color: rgba(170, 59, 255, 0.4);
+    color: rgba(255, 255, 255, 0.8);
+  }
+
+  &.active {
+    background: rgba(170, 59, 255, 0.2);
+    border-color: rgba(170, 59, 255, 0.6);
+    color: #c084fc;
+  }
+}
+
+// ── Alias ─────────────────────────────────────────────────────────────────
+.alias-input-row {
+  display: flex;
+  gap: 8px;
+
+  .field-input { flex: 1; }
+}
+
+.alias-add-btn {
+  padding: 0 18px;
+  border-radius: 10px;
+  border: 1px solid rgba(170, 59, 255, 0.35);
+  background: rgba(170, 59, 255, 0.1);
+  color: #c084fc;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: system-ui, sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+  flex-shrink: 0;
+
+  &:hover {
+    background: rgba(170, 59, 255, 0.2);
+    border-color: rgba(170, 59, 255, 0.6);
+  }
+}
+
+.alias-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.alias-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  background: rgba(170, 59, 255, 0.12);
+  border: 1px solid rgba(170, 59, 255, 0.25);
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  font-family: system-ui, sans-serif;
+}
+
+.alias-tag-remove {
+  display: flex;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 0;
+  color: rgba(255, 255, 255, 0.3);
+  cursor: pointer;
+  line-height: 1;
+  transition: color 0.15s;
+
+  &:hover { color: rgba(255, 100, 100, 0.8); }
+}
+
+// ── 맵 크기 ──────────────────────────────────────────────────────────────
+.size-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.size-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  cursor: pointer;
+  transition: all 0.15s;
+
+  &:hover {
+    border-color: rgba(170, 59, 255, 0.4);
+    background: rgba(170, 59, 255, 0.05);
+  }
+
+  &.active {
+    background: rgba(170, 59, 255, 0.15);
+    border-color: rgba(170, 59, 255, 0.55);
+
+    .size-label { color: #c084fc; }
+    .size-value { color: rgba(192, 132, 252, 0.7); }
+  }
+}
+
+.size-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.75);
+  font-family: system-ui, sans-serif;
+}
+
+.size-value {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.3);
+  font-family: system-ui, sans-serif;
+  font-variant-numeric: tabular-nums;
+}
+
+.size-custom {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  margin-top: 4px;
+
+  .field { max-width: 140px; }
+}
+
+.size-cross {
+  font-size: 18px;
+  color: rgba(255, 255, 255, 0.25);
+  padding-bottom: 10px;
+  font-family: system-ui, sans-serif;
+}
+
+// ── 타일 셋 ──────────────────────────────────────────────────────────────
+.tileset-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+
+  @media (max-width: 560px) { grid-template-columns: repeat(2, 1fr); }
+}
+
+.tileset-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  cursor: pointer;
+  transition: all 0.15s;
+  text-align: left;
+
+  &:hover {
+    border-color: var(--tileset-color, rgba(255,255,255,0.3));
+    background: var(--tileset-bg, rgba(255,255,255,0.05));
+  }
+
+  &.active {
+    border-color: var(--tileset-color, rgba(255,255,255,0.5));
+    background: var(--tileset-bg, rgba(255,255,255,0.08));
+
+    .tileset-dot { box-shadow: 0 0 6px var(--tileset-color); }
+    .tileset-name { color: #fff; }
+  }
+}
+
+.tileset-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--tileset-color, #fff);
+  flex-shrink: 0;
+  transition: box-shadow 0.2s;
+}
+
+.tileset-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.65);
+  font-family: system-ui, sans-serif;
+  flex: 1;
+}
+
+.tileset-en {
+  display: none; // 공간 절약 (hover tooltip 등으로 활용 가능)
+}
+
+// ── 제출 버튼 영역 ────────────────────────────────────────────────────────
+.form-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  padding-top: 4px;
+}
+
+.submit-error {
+  flex: 1;
+  font-size: 13px;
+  color: #f87171;
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+
+.btn-cancel {
+  padding: 12px 22px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.45);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: system-ui, sans-serif;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.2);
+    color: rgba(255, 255, 255, 0.7);
+  }
+}
+
+.btn-submit {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 28px;
+  border-radius: 10px;
+  border: none;
+  background: linear-gradient(135deg, #aa3bff, #5865f2);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 700;
+  font-family: system-ui, sans-serif;
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(170, 59, 255, 0.35);
+  transition: all 0.2s;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 28px rgba(170, 59, 255, 0.5);
+  }
+
+  &:active:not(:disabled) { transform: translateY(0); }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.spin {
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/views/MapRegisterView.vue
+++ b/src/views/MapRegisterView.vue
@@ -1,0 +1,325 @@
+<template>
+  <div class="map-register-page">
+    <AppHeader />
+
+    <div class="orb orb-1"></div>
+    <div class="orb orb-2"></div>
+    <div class="grid-overlay"></div>
+
+    <div class="page-inner">
+      <!-- Header -->
+      <header class="page-header">
+        <div class="page-title">
+          <h1>맵 등록</h1>
+          <p>스타크래프트1 리마스터 맵 정보를 입력하세요</p>
+        </div>
+      </header>
+
+      <form class="register-form" @submit.prevent="handleSubmit">
+
+        <!-- 이미지 업로드 -->
+        <section class="form-section">
+          <h2 class="section-title">맵 이미지</h2>
+          <div
+            class="image-upload"
+            :class="{ 'has-image': previewUrl, 'drag-over': isDragOver }"
+            @dragover.prevent="isDragOver = true"
+            @dragleave="isDragOver = false"
+            @drop.prevent="onDrop"
+            @click="fileInput?.click()"
+          >
+            <input
+              ref="fileInput"
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              style="display:none"
+              @change="onFileChange"
+            />
+            <img v-if="previewUrl" :src="previewUrl" class="image-preview" alt="맵 미리보기" />
+            <div v-else class="upload-placeholder">
+              <svg width="40" height="40" viewBox="0 0 40 40" fill="none">
+                <rect width="40" height="40" rx="10" fill="rgba(170,59,255,0.1)"/>
+                <path d="M13 28L19 18L23 23L26 19L32 28H13Z" stroke="rgba(170,59,255,0.6)" stroke-width="1.5" stroke-linejoin="round" fill="rgba(170,59,255,0.08)"/>
+                <circle cx="16" cy="16" r="2.5" stroke="rgba(170,59,255,0.6)" stroke-width="1.5"/>
+              </svg>
+              <span class="upload-label">이미지를 드래그하거나 클릭하여 업로드</span>
+              <span class="upload-hint">PNG, JPG, WebP · 권장 비율 4:3</span>
+            </div>
+            <button v-if="previewUrl" type="button" class="image-remove" @click.stop="removeImage">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <path d="M2 2L12 12M12 2L2 12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              </svg>
+            </button>
+          </div>
+        </section>
+
+        <!-- 기본 정보 -->
+        <section class="form-section">
+          <h2 class="section-title">기본 정보</h2>
+          <div class="field-row">
+            <div class="field">
+              <label class="field-label">맵 이름</label>
+              <input
+                v-model="form.name"
+                type="text"
+                class="field-input"
+                placeholder="예) 투혼, 폴립, 블리자드..."
+                required
+              />
+            </div>
+            <div class="field field--small">
+              <label class="field-label">인원 수</label>
+              <div class="player-selector">
+                <button
+                  v-for="n in 8"
+                  :key="n"
+                  type="button"
+                  class="player-btn"
+                  :class="{ active: form.playerCount === n }"
+                  @click="form.playerCount = n"
+                >{{ n }}</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Alias -->
+        <section class="form-section">
+          <h2 class="section-title">Alias</h2>
+          <div class="field">
+            <label class="field-label">다른 이름 (영문명, 버전명 등)</label>
+            <div class="alias-input-row">
+              <input
+                v-model="aliasInput"
+                type="text"
+                class="field-input"
+                placeholder="예) Fight Spirit, 투혼 1.3 ..."
+                @keydown.enter.prevent="addAlias"
+              />
+              <button type="button" class="alias-add-btn" @click="addAlias">추가</button>
+            </div>
+            <div v-if="form.aliases.length" class="alias-tags">
+              <span v-for="(alias, i) in form.aliases" :key="i" class="alias-tag">
+                {{ alias }}
+                <button type="button" class="alias-tag-remove" @click="removeAlias(i)">
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                    <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+                  </svg>
+                </button>
+              </span>
+            </div>
+          </div>
+        </section>
+
+        <!-- 맵 크기 -->
+        <section class="form-section">
+          <h2 class="section-title">맵 크기</h2>
+          <div class="size-presets">
+            <button
+              v-for="preset in sizePresets"
+              :key="preset.label"
+              type="button"
+              class="size-btn"
+              :class="{ active: isSizeActive(preset) }"
+              @click="applyPreset(preset)"
+            >
+              <span class="size-label">{{ preset.label }}</span>
+              <span class="size-value">{{ preset.w }}×{{ preset.h }}</span>
+            </button>
+            <button
+              type="button"
+              class="size-btn"
+              :class="{ active: isCustomSize }"
+              @click="setCustom"
+            >
+              <span class="size-label">직접 입력</span>
+              <span class="size-value">Custom</span>
+            </button>
+          </div>
+          <div v-if="isCustomSize" class="size-custom">
+            <div class="field">
+              <label class="field-label">가로 (W)</label>
+              <input v-model.number="form.width" type="number" class="field-input" min="32" max="256" placeholder="128" />
+            </div>
+            <span class="size-cross">×</span>
+            <div class="field">
+              <label class="field-label">세로 (H)</label>
+              <input v-model.number="form.height" type="number" class="field-input" min="32" max="256" placeholder="128" />
+            </div>
+          </div>
+        </section>
+
+        <!-- 타일 셋 -->
+        <section class="form-section">
+          <h2 class="section-title">타일 셋</h2>
+          <div class="tileset-grid">
+            <button
+              v-for="tileset in tilesets"
+              :key="tileset.id"
+              type="button"
+              class="tileset-btn"
+              :class="{ active: form.tileset === tileset.id }"
+              :style="{ '--tileset-color': tileset.color, '--tileset-bg': tileset.bg }"
+              @click="form.tileset = tileset.id"
+            >
+              <span class="tileset-dot"></span>
+              <span class="tileset-name">{{ tileset.name }}</span>
+              <span class="tileset-en">{{ tileset.en }}</span>
+            </button>
+          </div>
+        </section>
+
+        <!-- 제출 -->
+        <div class="form-footer">
+          <p v-if="submitError" class="submit-error">{{ submitError }}</p>
+          <button type="button" class="btn-cancel" @click="router.back()">취소</button>
+          <button type="submit" class="btn-submit" :disabled="submitting">
+            <svg v-if="!submitting" width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M3 8H13M9 4L13 8L9 12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <svg v-else width="16" height="16" viewBox="0 0 16 16" fill="none" class="spin">
+              <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="2" stroke-dasharray="28" stroke-dashoffset="10" stroke-linecap="round"/>
+            </svg>
+            {{ submitting ? '저장 중...' : '맵 등록하기' }}
+          </button>
+        </div>
+
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import AppHeader from '@/components/AppHeader.vue'
+import { createMap } from '@/lib/maps'
+
+const router = useRouter()
+
+// --- 폼 상태 ---
+const form = ref({
+  name: '',
+  playerCount: 2,
+  width: 128,
+  height: 128,
+  tileset: '',
+  imageFile: null as File | null,
+  aliases: [] as string[],
+})
+
+// --- Alias ---
+const aliasInput = ref('')
+
+function addAlias() {
+  const val = aliasInput.value.trim()
+  if (val && !form.value.aliases.includes(val)) {
+    form.value.aliases.push(val)
+  }
+  aliasInput.value = ''
+}
+
+function removeAlias(i: number) {
+  form.value.aliases.splice(i, 1)
+}
+
+// --- 이미지 ---
+const fileInput = ref<HTMLInputElement | null>(null)
+const previewUrl = ref<string | null>(null)
+const isDragOver = ref(false)
+
+function onFileChange(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (file) setImage(file)
+}
+
+function onDrop(e: DragEvent) {
+  isDragOver.value = false
+  const file = e.dataTransfer?.files?.[0]
+  if (file && ['image/png', 'image/jpeg', 'image/webp'].includes(file.type)) setImage(file)
+}
+
+function setImage(file: File) {
+  form.value.imageFile = file
+  previewUrl.value = URL.createObjectURL(file)
+}
+
+function removeImage() {
+  form.value.imageFile = null
+  previewUrl.value = null
+  if (fileInput.value) fileInput.value.value = ''
+}
+
+// --- 맵 크기 ---
+const sizePresets = [
+  { label: '소형', w: 64,  h: 64  },
+  { label: '중소형', w: 96,  h: 96  },
+  { label: '중형', w: 128, h: 96  },
+  { label: '표준', w: 128, h: 128 },
+  { label: '대형', w: 192, h: 192 },
+  { label: '초대형', w: 256, h: 256 },
+]
+
+const isCustomSize = ref(false)
+
+function isSizeActive(preset: typeof sizePresets[0]) {
+  return !isCustomSize.value && form.value.width === preset.w && form.value.height === preset.h
+}
+
+function applyPreset(preset: typeof sizePresets[0]) {
+  isCustomSize.value = false
+  form.value.width = preset.w
+  form.value.height = preset.h
+}
+
+function setCustom() {
+  isCustomSize.value = true
+}
+
+// --- 타일 셋 ---
+const tilesets = [
+  { id: 'badlands',  name: '황무지',     en: 'Badlands',         color: '#c97d3a', bg: 'rgba(201,125,58,0.1)'  },
+  { id: 'space',     name: '우주 정거장', en: 'Space Platform',   color: '#4a8fcc', bg: 'rgba(74,143,204,0.1)'  },
+  { id: 'install',   name: '설치물',     en: 'Installation',     color: '#7a8a9a', bg: 'rgba(122,138,154,0.1)' },
+  { id: 'ashworld',  name: '화산 지대',  en: 'Ashworld',         color: '#cc4a2f', bg: 'rgba(204,74,47,0.1)'   },
+  { id: 'jungle',    name: '정글',       en: 'Jungle World',     color: '#3a9a4a', bg: 'rgba(58,154,74,0.1)'   },
+  { id: 'desert',    name: '사막',       en: 'Desert',           color: '#c9a83a', bg: 'rgba(201,168,58,0.1)'  },
+  { id: 'ice',       name: '얼음',       en: 'Ice',              color: '#7aaed4', bg: 'rgba(122,174,212,0.12)'},
+  { id: 'twilight',  name: '황혼',       en: 'Twilight',         color: '#9a4acc', bg: 'rgba(154,74,204,0.1)'  },
+]
+
+// --- 제출 ---
+const submitting = ref(false)
+const submitError = ref<string | null>(null)
+
+async function handleSubmit() {
+  if (!form.value.tileset) {
+    submitError.value = '타일 셋을 선택해주세요.'
+    return
+  }
+
+  submitting.value = true
+  submitError.value = null
+
+  try {
+    await createMap({
+      name: form.value.name,
+      aliases: form.value.aliases,
+      width: form.value.width,
+      height: form.value.height,
+      player_count: form.value.playerCount,
+      tileset: form.value.tileset,
+      imageFile: form.value.imageFile,
+    })
+    router.push({ name: 'home' })
+  } catch (e: any) {
+    submitError.value = e.message ?? '저장 중 오류가 발생했습니다.'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@use './MapRegisterView.scss';
+</style>


### PR DESCRIPTION
- AppHeader 컴포넌트 분리 (브랜드 로고, 네비게이션, 디스코드 아바타, 로그아웃)
- MapRegisterView 추가: 맵 이름/이미지/크기/인원/타일셋/alias 입력 폼
- maps.ts 서비스 레이어: Supabase Storage 이미지 업로드 + 테이블 저장
- /maps/register 라우트 추가 (requiresAuth)
- HomeView에 맵 등록 버튼 연결
- .gitignore에 .mcp.json 추가