### PR TITLE
feat: 경기 결과 등록 기능 #25

### DIFF
--- a/src/components/EntryRevealModal.scss
+++ b/src/components/EntryRevealModal.scss
@@ -110,19 +110,14 @@
 .reveal-slot {
   padding: 12px 0;
   border-top: 1px solid var(--c-border);
-
-  &--team .rsl-type {
-    color: #93c5fd;
-    background: rgba(96, 165, 250, 0.12);
-    border-color: rgba(96, 165, 250, 0.3);
-  }
 }
 
-.reveal-slot-label {
+.rsl-center-label {
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin-bottom: 8px;
+  justify-content: center;
+  gap: 5px;
+  margin-bottom: 6px;
 }
 
 .rsl-num {
@@ -168,25 +163,20 @@
   &--right { flex-direction: row-reverse; }
 }
 
-.rse-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--c-text-bright);
+.rse-name-badge {
+  font-size: 12px;
+  font-weight: 700;
   font-family: system-ui, sans-serif;
+  padding: 2px 7px;
+  border-radius: 5px;
 }
 
-.rse-tier {
+.rse-race {
   font-size: 10px;
   font-weight: 700;
   font-family: system-ui, sans-serif;
   padding: 2px 5px;
   border-radius: 4px;
-
-  &.tier--a { color: #fbbf24; background: rgba(251, 191, 36, 0.15); }
-  &.tier--b { color: #60a5fa; background: rgba(96, 165, 250, 0.15); }
-  &.tier--c { color: #4ade80; background: rgba(74, 222, 128, 0.12); }
-  &.tier--d { color: #fb923c; background: rgba(249, 115, 22, 0.12); }
-  &.tier--e { color: var(--c-text-faint); background: var(--c-badge-bg); }
 }
 
 .rse-pt {
@@ -227,7 +217,6 @@
   width: 100%;
   padding: 6px 8px;
   border-radius: 8px;
-  border: 1px solid var(--c-border);
   background: var(--c-surface-raised);
   transition: all 0.12s;
 
@@ -277,8 +266,12 @@
   font-size: 9px;
   font-weight: 700;
   font-family: system-ui, sans-serif;
-  padding: 1px 5px;
+  padding: 2px 6px;
   border-radius: 3px;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 
   &--a {
     color: #fbbf24;
@@ -290,6 +283,35 @@
     background: rgba(96, 165, 250, 0.15);
     border: 1px solid rgba(96, 165, 250, 0.3);
   }
+}
+
+// ── 사다리타기 / 밴 토글 ──────────────────────────────────────
+.rse-undecided {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: system-ui, sans-serif;
+  color: var(--c-text-muted);
+  text-align: center;
+  padding: 4px 0;
+}
+
+.btn-ban-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  padding: 4px 0;
+  background: none;
+  border: none;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: system-ui, sans-serif;
+  color: var(--c-text-faint);
+  cursor: pointer;
+  transition: color 0.15s;
+
+  &:hover { color: var(--c-text-muted); }
 }
 
 // ── 합계 ─────────────────────────────────────────────────────

--- a/src/components/EntryRevealModal.vue
+++ b/src/components/EntryRevealModal.vue
@@ -31,14 +31,6 @@
 
             <!-- 슬롯별 행 -->
             <div v-for="slot in SLOT_CONFIG" :key="slot.num" class="reveal-slot" :class="{ 'reveal-slot--team': slot.type === 'team' }">
-              <!-- 슬롯 라벨 -->
-              <div class="reveal-slot-label">
-                <span class="rsl-num">경기{{ slot.num }}</span>
-                <span class="rsl-type" :class="slot.type === 'team' ? 'rsl-type--team' : 'rsl-type--ind'">
-                  {{ slot.type === 'team' ? '팀전' : '개인전' }}
-                </span>
-              </div>
-
               <!-- 3컬럼: 팀A | 맵 | 팀B -->
               <div class="reveal-row">
                 <!-- 팀A 선수 -->
@@ -48,8 +40,8 @@
                     :key="pid"
                     class="rse-player"
                   >
-                    <span class="rse-name">{{ playerName(pid) }}</span>
-                    <span class="rse-tier" :class="`tier--${playerTier(pid).toLowerCase()}`">{{ playerTier(pid) }}</span>
+                    <span class="rse-name-badge" :class="`tier-badge--${playerTier(pid).toLowerCase()}`">{{ playerName(pid) }}</span>
+                    <span class="rse-race" :class="`race-badge--${playerRace(pid).toLowerCase()}`">{{ playerRace(pid) }}</span>
                     <span class="rse-pt">{{ playerPt(pid) }}pt</span>
                   </div>
                   <div v-if="slot.type === 'team' && getSlotPlayerIds(teamACaptainId, slot.num).length" class="rse-total">
@@ -59,25 +51,58 @@
 
                 <!-- 맵 정보 (센터) -->
                 <div class="rse-maps">
+                  <!-- 슬롯 라벨 -->
+                  <div class="rsl-center-label">
+                    <span class="rsl-num">경기{{ slot.num }}</span>
+                    <span v-if="slot.type === 'team'" class="rsl-type">
+                      팀전
+                    </span>
+                  </div>
                   <template v-if="slotMapRows[slot.num]?.length">
-                    <div
-                      v-for="m in slotMapRows[slot.num]"
-                      :key="m.id"
-                      class="rse-map-item"
-                      :class="{
-                        'rse-map--banned': getBan(teamACaptainId, slot.num) === m.id || getBan(teamBCaptainId, slot.num) === m.id,
-                      }"
+                    <!-- 경기 맵 (밴 제외, 항상 노출) -->
+                    <template v-for="m in slotMapRows[slot.num]" :key="m.id">
+                      <div v-if="slotMapResults[slot.num].matchMapIds.has(m.id)" class="rse-map-item">
+                        <div class="rse-map-thumb-wrap">
+                          <img v-if="m.thumbnail_url" :src="m.thumbnail_url" class="rse-map-thumb" />
+                          <div v-else class="rse-map-thumb-empty" />
+                        </div>
+                        <span class="rse-map-name">{{ m.name }}</span>
+                      </div>
+                    </template>
+
+                    <!-- 사다리타기 안내 -->
+                    <div v-if="slotMapResults[slot.num].isUndecided" class="rse-undecided">사다리타기로 결정</div>
+
+                    <!-- 밴 정보 토글 버튼 -->
+                    <button
+                      v-if="slotMapResults[slot.num].bannedMapInfo.length"
+                      class="btn-ban-toggle"
+                      @click="toggleBanInfo(slot.num)"
                     >
-                      <div class="rse-map-thumb-wrap">
-                        <img v-if="m.thumbnail_url" :src="m.thumbnail_url" class="rse-map-thumb" />
-                        <div v-else class="rse-map-thumb-empty" />
+                      밴 정보
+                      <svg width="10" height="10" viewBox="0 0 10 10" fill="none" style="transition: transform 0.15s" :style="{ transform: expandedBanSlots.includes(slot.num) ? 'rotate(180deg)' : 'none' }">
+                        <path d="M2 3.5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                      </svg>
+                    </button>
+
+                    <!-- 밴된 맵 (확장 시) -->
+                    <template v-if="expandedBanSlots.includes(slot.num)">
+                      <div
+                        v-for="ban in slotMapResults[slot.num].bannedMapInfo"
+                        :key="`ban-${ban.mapId}`"
+                        class="rse-map-item rse-map--banned"
+                      >
+                        <div class="rse-map-thumb-wrap">
+                          <img v-if="getMapInfo(slot.num, ban.mapId)?.thumbnail_url" :src="getMapInfo(slot.num, ban.mapId)!.thumbnail_url!" class="rse-map-thumb" />
+                          <div v-else class="rse-map-thumb-empty" />
+                        </div>
+                        <span class="rse-map-name">{{ getMapInfo(slot.num, ban.mapId)?.name }}</span>
+                        <div class="rse-ban-chips">
+                          <span v-if="ban.byTeamA" class="ban-chip ban-chip--a">{{ teamAName }} 밴</span>
+                          <span v-if="ban.byTeamB" class="ban-chip ban-chip--b">{{ teamBName }} 밴</span>
+                        </div>
                       </div>
-                      <span class="rse-map-name">{{ m.name }}</span>
-                      <div class="rse-ban-chips">
-                        <span v-if="getBan(teamACaptainId, slot.num) === m.id" class="ban-chip ban-chip--a">A밴</span>
-                        <span v-if="getBan(teamBCaptainId, slot.num) === m.id" class="ban-chip ban-chip--b">B밴</span>
-                      </div>
-                    </div>
+                    </template>
                   </template>
                   <div v-else class="rse-map-empty" />
                 </div>
@@ -90,8 +115,8 @@
                     class="rse-player rse-player--right"
                   >
                     <span class="rse-pt">{{ playerPt(pid) }}pt</span>
-                    <span class="rse-tier" :class="`tier--${playerTier(pid).toLowerCase()}`">{{ playerTier(pid) }}</span>
-                    <span class="rse-name">{{ playerName(pid) }}</span>
+                    <span class="rse-race" :class="`race-badge--${playerRace(pid).toLowerCase()}`">{{ playerRace(pid) }}</span>
+                    <span class="rse-name-badge" :class="`tier-badge--${playerTier(pid).toLowerCase()}`">{{ playerName(pid) }}</span>
                   </div>
                   <div v-if="slot.type === 'team' && getSlotPlayerIds(teamBCaptainId, slot.num).length" class="rse-total rse-total--right">
                     합계 {{ slotTotal(teamBCaptainId, slot.num) }}pt
@@ -120,7 +145,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { getScheduleEntries, TIER_POINTS, type EntryRecord } from '@/lib/entries'
 import { getMatchMaps } from '@/lib/leagueDetail'
 import { getMaps } from '@/lib/maps'
@@ -212,6 +237,10 @@ function playerTier(id: number): string {
   return playerMap.value.get(id)?.tier ?? '?'
 }
 
+function playerRace(id: number): string {
+  return playerMap.value.get(id)?.race ?? '?'
+}
+
 function playerPt(id: number): number {
   return TIER_POINTS[playerTier(id)] ?? 0
 }
@@ -225,6 +254,87 @@ function totalPoints(captainId: number): number {
     (sum, e) => sum + e.player_ids.reduce((s, id) => s + playerPt(id), 0),
     0,
   )
+}
+
+// ── 밴 로직 ───────────────────────────────────────────────────
+
+const TIER_RANK: Record<string, number> = { A: 5, B: 4, C: 3, D: 2, E: 1 }
+
+interface SlotMapResult {
+  matchMapIds: Set<string>
+  bannedMapInfo: { mapId: string; byTeamA: boolean; byTeamB: boolean }[]
+  isUndecided: boolean
+}
+
+const slotMapResults = computed<Record<number, SlotMapResult>>(() => {
+  const results: Record<number, SlotMapResult> = {}
+  for (const slot of SLOT_CONFIG) {
+    const n = slot.num
+    const maps = slotMapRows.value[n] ?? []
+    const banA = getBan(props.teamACaptainId, n)
+    const banB = getBan(props.teamBCaptainId, n)
+    const matchMapIds = new Set<string>()
+    const bannedMapInfo: SlotMapResult['bannedMapInfo'] = []
+    let isUndecided = false
+
+    if (maps.length <= 1 || (!banA && !banB)) {
+      maps.forEach(m => matchMapIds.add(m.id))
+    } else if (maps.length === 3) {
+      if (banA && banB) {
+        if (banA === banB) {
+          // 같은 맵 밴 → 나머지 2개 사다리타기
+          bannedMapInfo.push({ mapId: banA, byTeamA: true, byTeamB: true })
+          maps.filter(m => m.id !== banA).forEach(m => matchMapIds.add(m.id))
+          isUndecided = true
+        } else {
+          // 서로 다른 맵 밴 → 양쪽 밴 적용, 남은 1개가 경기 맵
+          bannedMapInfo.push({ mapId: banA, byTeamA: true, byTeamB: false })
+          bannedMapInfo.push({ mapId: banB, byTeamA: false, byTeamB: true })
+          maps.filter(m => m.id !== banA && m.id !== banB).forEach(m => matchMapIds.add(m.id))
+        }
+      } else {
+        const banId = banA ?? banB!
+        bannedMapInfo.push({ mapId: banId, byTeamA: !!banA, byTeamB: !!banB })
+        maps.filter(m => m.id !== banId).forEach(m => matchMapIds.add(m.id))
+      }
+    } else if (maps.length === 2) {
+      if (banA && banB) {
+        if (banA === banB) {
+          // 같은 맵 밴 → 나머지 1개가 경기 맵
+          bannedMapInfo.push({ mapId: banA, byTeamA: true, byTeamB: true })
+          maps.filter(m => m.id !== banA).forEach(m => matchMapIds.add(m.id))
+        } else {
+          // 서로 다른 맵 밴 → 티어 낮은 팀의 밴 우선
+          const rankA = TIER_RANK[playerTier(props.teamACaptainId)] ?? 0
+          const rankB = TIER_RANK[playerTier(props.teamBCaptainId)] ?? 0
+          const effectiveId = rankA <= rankB ? banA : banB
+          bannedMapInfo.push({ mapId: effectiveId, byTeamA: rankA <= rankB, byTeamB: rankB < rankA })
+          maps.filter(m => m.id !== effectiveId).forEach(m => matchMapIds.add(m.id))
+        }
+      } else {
+        const banId = banA ?? banB!
+        bannedMapInfo.push({ mapId: banId, byTeamA: !!banA, byTeamB: !!banB })
+        maps.filter(m => m.id !== banId).forEach(m => matchMapIds.add(m.id))
+      }
+    } else {
+      maps.forEach(m => matchMapIds.add(m.id))
+    }
+
+    results[n] = { matchMapIds, bannedMapInfo, isUndecided }
+  }
+  return results
+})
+
+const expandedBanSlots = ref<number[]>([])
+
+function toggleBanInfo(slotNum: number) {
+  const idx = expandedBanSlots.value.indexOf(slotNum)
+  if (idx >= 0) expandedBanSlots.value.splice(idx, 1)
+  else expandedBanSlots.value.push(slotNum)
+}
+
+function getMapInfo(slotNum: number, mapId: string) {
+  return slotMapRows.value[slotNum]?.find(m => m.id === mapId)
 }
 </script>
 

--- a/src/lib/schedules.ts
+++ b/src/lib/schedules.ts
@@ -51,6 +51,43 @@ export async function getRevealedSchedules(leagueId: string): Promise<ScheduleRo
   return data
 }
 
+// ── 경기별 슬롯 결과 ──────────────────────────────────────────
+
+export interface SlotResult {
+  schedule_id: number
+  slot_num: number
+  winner_captain_id: number | null
+}
+
+export async function getSlotResults(scheduleId: number): Promise<SlotResult[]> {
+  const { data, error } = await supabase
+    .from('league_match_slot_results')
+    .select('*')
+    .eq('schedule_id', scheduleId)
+  if (error) throw error
+  return data
+}
+
+export async function setSlotResult(
+  scheduleId: number,
+  slotNum: number,
+  winnerCaptainId: number | null,
+): Promise<void> {
+  if (winnerCaptainId === null) {
+    const { error } = await supabase
+      .from('league_match_slot_results')
+      .delete()
+      .eq('schedule_id', scheduleId)
+      .eq('slot_num', slotNum)
+    if (error) throw error
+  } else {
+    const { error } = await supabase
+      .from('league_match_slot_results')
+      .upsert({ schedule_id: scheduleId, slot_num: slotNum, winner_captain_id: winnerCaptainId })
+    if (error) throw error
+  }
+}
+
 export async function saveSchedules(
   leagueId: string,
   schedules: Array<{ round: number; match_date: string | null; team_a_captain_id: number; team_b_captain_id: number }>,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -76,6 +76,12 @@ const router = createRouter({
       meta: { requiresAuth: true, requiresAdmin: true },
     },
     {
+      path: '/leagues/:id/schedule/:matchId/result',
+      name: 'league-match-slot-result',
+      component: () => import('@/views/leagues/MatchSlotResultView.vue'),
+      meta: { requiresAuth: true, requiresAdmin: true },
+    },
+    {
       path: '/participate',
       name: 'participate',
       component: () => import('@/views/participate/ParticipateView.vue'),

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -17,26 +17,35 @@ export const useAuthStore = defineStore('auth', () => {
     isAdmin.value = data?.is_admin === true
   }
 
-  async function init() {
-    const { data } = await supabase.auth.getSession()
-    user.value = data.session?.user ?? null
+  let _initPromise: Promise<void> | null = null
 
-    if (user.value) {
-      const discordId = user.value.identities?.find(i => i.provider === 'discord')?.id ?? ''
-      if (discordId) await fetchIsAdmin(discordId)
-    }
+  function init(): Promise<void> {
+    if (_initPromise) return _initPromise
+    _initPromise = new Promise<void>((resolve) => {
+      let resolved = false
 
-    loading.value = false
+      // 콜백을 async로 만들지 않음 — Supabase v2는 auth lock 안에서 콜백을 await하므로,
+      // 콜백 안에서 supabase DB 쿼리를 await하면 getSession() → _acquireLock() 데드락 발생.
+      // setTimeout(0)으로 DB 호출을 auth lock 컨텍스트 바깥으로 꺼낸다.
+      supabase.auth.onAuthStateChange((_event, session) => {
+        user.value = session?.user ?? null
+        if (!user.value) isAdmin.value = false
 
-    supabase.auth.onAuthStateChange(async (_event, session) => {
-      user.value = session?.user ?? null
-      if (user.value) {
-        const discordId = user.value.identities?.find(i => i.provider === 'discord')?.id ?? ''
-        if (discordId) await fetchIsAdmin(discordId)
-      } else {
-        isAdmin.value = false
-      }
+        const discordId = user.value?.identities?.find(i => i.provider === 'discord')?.id ?? ''
+
+        setTimeout(async () => {
+          try {
+            if (discordId) await fetchIsAdmin(discordId)
+          } catch {}
+          if (!resolved) {
+            resolved = true
+            loading.value = false
+            resolve()
+          }
+        }, 0)
+      })
     })
+    return _initPromise
   }
 
   async function loginWithDiscord() {

--- a/src/views/leagues/MatchSlotResultView.scss
+++ b/src/views/leagues/MatchSlotResultView.scss
@@ -1,0 +1,284 @@
+@use '../../styles/page';
+
+.slot-result-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.slot-result-content {
+  flex: 1;
+  max-width: 640px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 40px 28px 80px;
+  box-sizing: border-box;
+  animation: fadeUp 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.state-msg {
+  padding: 60px 0;
+  text-align: center;
+  font-size: 13px;
+  color: var(--c-text-faint);
+  font-family: system-ui, sans-serif;
+  &--error { color: #f87171; }
+}
+
+// ── 경기 헤더 ──────────────────────────────────────────────
+.match-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 28px;
+  padding: 20px 24px;
+  border-radius: 14px;
+  border: 1px solid var(--c-border);
+  background: var(--c-surface-raised);
+}
+
+.match-info-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-text-muted);
+  font-family: system-ui, sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.match-info-teams {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+}
+
+.match-team-col {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+  flex: 1;
+
+  &--right {
+    align-items: flex-start;
+  }
+}
+
+.match-team-badge {
+  font-size: 14px;
+  font-weight: 700;
+  font-family: system-ui, sans-serif;
+  padding: 4px 12px;
+  border-radius: 7px;
+}
+
+.match-team-pts {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-text-muted);
+  font-family: system-ui, sans-serif;
+  letter-spacing: 0.3px;
+}
+
+.match-score-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.match-score {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--c-text-bright);
+  font-family: system-ui, sans-serif;
+  letter-spacing: 2px;
+}
+
+.match-info-date {
+  font-size: 11px;
+  color: var(--c-text-faint);
+  font-family: system-ui, sans-serif;
+}
+
+// ── 슬롯 리스트 ───────────────────────────────────────────
+.slot-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.slot-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--c-border);
+  background: var(--c-surface-raised);
+  transition: border-color 0.15s;
+
+  &--done {
+    border-color: rgba(52, 211, 153, 0.25);
+    background: rgba(52, 211, 153, 0.03);
+  }
+}
+
+// ── 슬롯 레이블 (경기N / 팀전 등) ─────────────────────────
+.slot-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  width: 52px;
+}
+
+.slot-num {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--c-text-2);
+  font-family: system-ui, sans-serif;
+  white-space: nowrap;
+}
+
+.slot-type {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--c-text-faint);
+  font-family: system-ui, sans-serif;
+  white-space: nowrap;
+
+  &--team {
+    color: #c084fc;
+  }
+}
+
+// ── 슬롯 팀 버튼들 ────────────────────────────────────────
+.slot-teams {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.slot-vs {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-text-faint);
+  font-family: system-ui, sans-serif;
+  flex-shrink: 0;
+}
+
+.slot-team-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  justify-content: flex-end;
+  padding: 7px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  cursor: pointer;
+  transition: all 0.14s;
+  min-width: 0;
+
+  &--right {
+    justify-content: flex-start;
+  }
+
+  &:hover:not(:disabled) {
+    border-color: rgba(52, 211, 153, 0.4);
+    background: rgba(52, 211, 153, 0.06);
+  }
+
+  &--winner {
+    border-color: rgba(52, 211, 153, 0.5);
+    background: rgba(52, 211, 153, 0.1);
+
+    &:hover:not(:disabled) {
+      border-color: rgba(52, 211, 153, 0.65);
+      background: rgba(52, 211, 153, 0.15);
+    }
+  }
+
+  &--loser {
+    opacity: 0.35;
+    cursor: default;
+  }
+
+  &--saving {
+    opacity: 0.6;
+    cursor: default;
+  }
+}
+
+.slot-team-name {
+  font-size: 12px;
+  font-weight: 700;
+  font-family: system-ui, sans-serif;
+  padding: 2px 8px;
+  border-radius: 5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
+.slot-players {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+
+  .slot-team-btn--right & {
+    align-items: flex-start;
+  }
+}
+
+.slot-player-row {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  justify-content: flex-end;
+
+  &--right {
+    justify-content: flex-start;
+  }
+}
+
+.slot-player-name {
+  font-size: 12px;
+  font-weight: 700;
+  font-family: system-ui, sans-serif;
+  padding: 2px 8px;
+  border-radius: 5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 130px;
+}
+
+.slot-race {
+  font-size: 10px;
+  font-weight: 800;
+  font-family: system-ui, sans-serif;
+  padding: 2px 5px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.win-badge {
+  font-size: 9px;
+  font-weight: 800;
+  color: #34d399;
+  letter-spacing: 0.5px;
+  font-family: system-ui, sans-serif;
+  flex-shrink: 0;
+}
+

--- a/src/views/leagues/MatchSlotResultView.vue
+++ b/src/views/leagues/MatchSlotResultView.vue
@@ -1,0 +1,333 @@
+<template>
+  <div class="slot-result-page">
+    <AppHeader />
+
+    <div class="slot-result-content">
+      <button class="btn-back" @click="$router.push({ name: 'league-schedule', params: { id: leagueId } })">
+        <AppIcon name="chevron-left" :size="13" />
+        경기 관리
+      </button>
+
+      <div v-if="loading" class="state-msg">불러오는 중...</div>
+      <div v-else-if="pageError" class="state-msg state-msg--error">{{ pageError }}</div>
+
+      <template v-else>
+        <!-- 헤더 -->
+        <div class="match-info">
+          <div class="match-info-title">경기 결과 입력</div>
+          <div class="match-info-teams">
+            <div class="match-team-col">
+              <span class="match-team-badge" :class="`tier-badge--${teamA?.tier.toLowerCase()}`">
+                {{ teamA?.teamName || teamA?.nickname }}
+              </span>
+              <span v-if="entryPointsA > 0" class="match-team-pts">{{ entryPointsA }}pt</span>
+            </div>
+            <div class="match-score-col">
+              <span class="match-score">{{ scoreA }} : {{ scoreB }}</span>
+              <div v-if="schedule?.match_date" class="match-info-date">
+                {{ schedule.match_date.replaceAll('-', '/') }}
+              </div>
+            </div>
+            <div class="match-team-col match-team-col--right">
+              <span class="match-team-badge" :class="`tier-badge--${teamB?.tier.toLowerCase()}`">
+                {{ teamB?.teamName || teamB?.nickname }}
+              </span>
+              <span v-if="entryPointsB > 0" class="match-team-pts">{{ entryPointsB }}pt</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- 슬롯별 결과 -->
+        <div class="slot-list">
+          <div
+            v-for="slot in REGULAR_SLOTS"
+            :key="slot.num"
+            class="slot-row"
+            :class="{ 'slot-row--done': slotWinners.get(slot.num) != null }"
+          >
+            <div class="slot-label">
+              <span class="slot-num">경기{{ slot.num }}</span>
+              <span class="slot-type" :class="slot.type === 'team' ? 'slot-type--team' : ''">
+                {{ slot.type === 'team' ? '팀전' : '개인전' }}
+              </span>
+            </div>
+
+            <div class="slot-teams">
+              <button
+                class="slot-team-btn"
+                :class="{
+                  'slot-team-btn--winner': slotWinners.get(slot.num) === schedule!.team_a_captain_id,
+                  'slot-team-btn--loser': slotWinners.get(slot.num) != null && slotWinners.get(slot.num) !== schedule!.team_a_captain_id,
+                  'slot-team-btn--saving': savingSlot === slot.num,
+                }"
+                :disabled="savingSlot === slot.num"
+                @click="toggleWinner(slot.num, schedule!.team_a_captain_id)"
+              >
+                <div class="slot-players">
+                  <template v-if="slotPlayerMap.get(slot.num)?.teamA?.length">
+                    <div v-for="p in slotPlayerMap.get(slot.num)!.teamA" :key="p.id" class="slot-player-row">
+                      <span v-if="p.race" class="slot-race" :class="`race-badge--${p.race.toLowerCase()}`">{{ p.race.toUpperCase() }}</span>
+                      <span class="slot-player-name" :class="`tier-badge--${p.tier.toLowerCase()}`">{{ p.nickname }}</span>
+                    </div>
+                  </template>
+                  <span v-else class="slot-team-name" :class="`tier-badge--${teamA?.tier.toLowerCase()}`">
+                    {{ teamA?.teamName || teamA?.nickname }}
+                  </span>
+                </div>
+                <span v-if="slotWinners.get(slot.num) === schedule!.team_a_captain_id" class="win-badge">WIN</span>
+              </button>
+
+              <span class="slot-vs">VS</span>
+
+              <button
+                class="slot-team-btn slot-team-btn--right"
+                :class="{
+                  'slot-team-btn--winner': slotWinners.get(slot.num) === schedule!.team_b_captain_id,
+                  'slot-team-btn--loser': slotWinners.get(slot.num) != null && slotWinners.get(slot.num) !== schedule!.team_b_captain_id,
+                  'slot-team-btn--saving': savingSlot === slot.num,
+                }"
+                :disabled="savingSlot === slot.num"
+                @click="toggleWinner(slot.num, schedule!.team_b_captain_id)"
+              >
+                <span v-if="slotWinners.get(slot.num) === schedule!.team_b_captain_id" class="win-badge">WIN</span>
+                <div class="slot-players">
+                  <template v-if="slotPlayerMap.get(slot.num)?.teamB?.length">
+                    <div v-for="p in slotPlayerMap.get(slot.num)!.teamB" :key="p.id" class="slot-player-row slot-player-row--right">
+                      <span class="slot-player-name" :class="`tier-badge--${p.tier.toLowerCase()}`">{{ p.nickname }}</span>
+                      <span v-if="p.race" class="slot-race" :class="`race-badge--${p.race.toLowerCase()}`">{{ p.race.toUpperCase() }}</span>
+                    </div>
+                  </template>
+                  <span v-else class="slot-team-name" :class="`tier-badge--${teamB?.tier.toLowerCase()}`">
+                    {{ teamB?.teamName || teamB?.nickname }}
+                  </span>
+                </div>
+              </button>
+            </div>
+          </div>
+          <!-- 에이스 결정전: 6경기 3:3이고 포인트 차이 3 미만일 때만 노출 -->
+          <div
+            v-if="showAce"
+            class="slot-row"
+            :class="{ 'slot-row--done': slotWinners.get(ACE_SLOT.num) != null }"
+          >
+            <div class="slot-label">
+              <span class="slot-num">에이스</span>
+              <span class="slot-type">결정전</span>
+            </div>
+
+            <div class="slot-teams">
+              <button
+                class="slot-team-btn"
+                :class="{
+                  'slot-team-btn--winner': slotWinners.get(ACE_SLOT.num) === schedule!.team_a_captain_id,
+                  'slot-team-btn--loser': slotWinners.get(ACE_SLOT.num) != null && slotWinners.get(ACE_SLOT.num) !== schedule!.team_a_captain_id,
+                  'slot-team-btn--saving': savingSlot === ACE_SLOT.num,
+                }"
+                :disabled="savingSlot === ACE_SLOT.num"
+                @click="toggleWinner(ACE_SLOT.num, schedule!.team_a_captain_id)"
+              >
+                <span class="slot-team-name" :class="`tier-badge--${teamA?.tier.toLowerCase()}`">
+                  {{ teamA?.teamName || teamA?.nickname }}
+                </span>
+                <span v-if="slotWinners.get(ACE_SLOT.num) === schedule!.team_a_captain_id" class="win-badge">WIN</span>
+              </button>
+
+              <span class="slot-vs">VS</span>
+
+              <button
+                class="slot-team-btn slot-team-btn--right"
+                :class="{
+                  'slot-team-btn--winner': slotWinners.get(ACE_SLOT.num) === schedule!.team_b_captain_id,
+                  'slot-team-btn--loser': slotWinners.get(ACE_SLOT.num) != null && slotWinners.get(ACE_SLOT.num) !== schedule!.team_b_captain_id,
+                  'slot-team-btn--saving': savingSlot === ACE_SLOT.num,
+                }"
+                :disabled="savingSlot === ACE_SLOT.num"
+                @click="toggleWinner(ACE_SLOT.num, schedule!.team_b_captain_id)"
+              >
+                <span v-if="slotWinners.get(ACE_SLOT.num) === schedule!.team_b_captain_id" class="win-badge">WIN</span>
+                <span class="slot-team-name" :class="`tier-badge--${teamB?.tier.toLowerCase()}`">
+                  {{ teamB?.teamName || teamB?.nickname }}
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import AppHeader from '@/components/AppHeader.vue'
+import AppIcon from '@/components/AppIcon.vue'
+import { getLeague } from '@/lib/leagues'
+import { getCaptains } from '@/lib/leagueDetail'
+import { getPlayers } from '@/lib/players'
+import { getTeamNames } from '@/lib/teamNames'
+import { getSchedules, getSlotResults, setSlotResult, type ScheduleRow } from '@/lib/schedules'
+import { getScheduleEntries } from '@/lib/entries'
+import { withTimeout } from '@/lib/supabase'
+
+const route = useRoute()
+const leagueId = route.params.id as string
+const matchId = Number(route.params.matchId)
+
+const REGULAR_SLOTS = [
+  { num: 1, type: 'individual' },
+  { num: 2, type: 'individual' },
+  { num: 3, type: 'individual' },
+  { num: 4, type: 'team' },
+  { num: 5, type: 'individual' },
+  { num: 6, type: 'individual' },
+] as const
+
+const ACE_SLOT = { num: 7, type: 'ace' } as const
+
+const TIER_POINTS: Record<string, number> = { A: 5, B: 4, C: 3, D: 2, E: 1 }
+
+interface TeamInfo {
+  captainId: number
+  nickname: string
+  teamName: string
+  tier: string
+}
+
+const loading = ref(true)
+const pageError = ref<string | null>(null)
+const savingSlot = ref<number | null>(null)
+
+interface SlotPlayerInfo { id: number; nickname: string; tier: string; race: string }
+interface SlotPlayers { teamA: SlotPlayerInfo[]; teamB: SlotPlayerInfo[] }
+
+const schedule = ref<ScheduleRow | null>(null)
+const teamA = ref<TeamInfo | null>(null)
+const teamB = ref<TeamInfo | null>(null)
+const slotWinners = ref(new Map<number, number>())
+const slotPlayerMap = ref(new Map<number, SlotPlayers>())
+const entryPointsA = ref(0)
+const entryPointsB = ref(0)
+
+// 1~6경기 스코어
+const score6A = computed(() =>
+  [...slotWinners.value.entries()].filter(([s, w]) => s !== ACE_SLOT.num && w === schedule.value?.team_a_captain_id).length
+)
+const score6B = computed(() =>
+  [...slotWinners.value.entries()].filter(([s, w]) => s !== ACE_SLOT.num && w === schedule.value?.team_b_captain_id).length
+)
+
+// 전체 스코어 (에이스 포함)
+const scoreA = computed(() =>
+  [...slotWinners.value.entries()].filter(([, w]) => w === schedule.value?.team_a_captain_id).length
+)
+const scoreB = computed(() =>
+  [...slotWinners.value.entries()].filter(([, w]) => w === schedule.value?.team_b_captain_id).length
+)
+
+// 3:3이고 포인트 차이가 3 미만일 때 에이스 결정전 진행
+const showAce = computed(() => {
+  if (score6A.value !== 3 || score6B.value !== 3) return false
+  if (entryPointsA.value === 0 && entryPointsB.value === 0) return true  // 엔트리 없으면 기본 진행
+  return Math.abs(entryPointsA.value - entryPointsB.value) < 3
+})
+
+onMounted(async () => {
+  try {
+    const [leagueData, captains, players, teamNames, schedules, slotResults, entries] = await withTimeout(Promise.all([
+      getLeague(leagueId),
+      getCaptains(leagueId),
+      getPlayers(),
+      getTeamNames(leagueId),
+      getSchedules(leagueId),
+      getSlotResults(matchId),
+      getScheduleEntries(matchId),
+    ]))
+
+    void leagueData
+
+    const match = schedules.find(s => s.id === matchId)
+    if (!match) throw new Error('경기를 찾을 수 없습니다.')
+    schedule.value = match
+
+    const playerMap = new Map(players.map(p => [p.id, p]))
+    const nameMap = new Map(teamNames.map(t => [t.captain_player_id, t.team_name]))
+
+    const makeTeam = (captainId: number): TeamInfo => {
+      const p = playerMap.get(captainId)
+      return {
+        captainId,
+        nickname: p?.nickname ?? `선수 ${captainId}`,
+        teamName: nameMap.get(captainId) ?? '',
+        tier: p?.tier ?? 'e',
+      }
+    }
+
+    const captainIds = captains.map(c => c.player_id)
+    if (captainIds.includes(match.team_a_captain_id)) teamA.value = makeTeam(match.team_a_captain_id)
+    if (captainIds.includes(match.team_b_captain_id)) teamB.value = makeTeam(match.team_b_captain_id)
+
+    const winnerMap = new Map<number, number>()
+    for (const r of slotResults) {
+      if (r.winner_captain_id != null) winnerMap.set(r.slot_num, r.winner_captain_id)
+    }
+    slotWinners.value = winnerMap
+
+    // 슬롯별 선수 맵 구성 (엔트리 공개된 경우에만 데이터 있음)
+    const toInfo = (id: number): SlotPlayerInfo => {
+      const p = playerMap.get(id)
+      return { id, nickname: p?.nickname ?? `선수${id}`, tier: p?.tier ?? 'e', race: p?.race ?? '' }
+    }
+    const aEntries = entries.filter(e => e.captain_player_id === match.team_a_captain_id)
+    const bEntries = entries.filter(e => e.captain_player_id === match.team_b_captain_id)
+    const spMap = new Map<number, SlotPlayers>()
+    const allSlots = new Set([...aEntries.map(e => e.match_slot), ...bEntries.map(e => e.match_slot)])
+    for (const slotNum of allSlots) {
+      const aSlot = aEntries.find(e => e.match_slot === slotNum)
+      const bSlot = bEntries.find(e => e.match_slot === slotNum)
+      spMap.set(slotNum, {
+        teamA: (aSlot?.player_ids ?? []).map(toInfo),
+        teamB: (bSlot?.player_ids ?? []).map(toInfo),
+      })
+    }
+    slotPlayerMap.value = spMap
+
+    // 팀별 총 포인트 계산 (슬롯 1~6)
+    const calcPoints = (captainId: number) =>
+      entries
+        .filter(e => e.captain_player_id === captainId)
+        .flatMap(e => e.player_ids)
+        .reduce((sum, pid) => sum + (TIER_POINTS[(playerMap.get(pid)?.tier ?? 'e').toUpperCase()] ?? 1), 0)
+    entryPointsA.value = calcPoints(match.team_a_captain_id)
+    entryPointsB.value = calcPoints(match.team_b_captain_id)
+  } catch (e: any) {
+    pageError.value = e.message ?? '데이터를 불러올 수 없습니다.'
+  } finally {
+    loading.value = false
+  }
+})
+
+async function toggleWinner(slotNum: number, captainId: number) {
+  if (savingSlot.value != null) return
+  const current = slotWinners.value.get(slotNum)
+  const next = current === captainId ? null : captainId
+
+  savingSlot.value = slotNum
+  try {
+    await setSlotResult(matchId, slotNum, next)
+    const map = new Map(slotWinners.value)
+    if (next == null) map.delete(slotNum)
+    else map.set(slotNum, next)
+    slotWinners.value = map
+  } catch (e: any) {
+    console.error(e)
+  } finally {
+    savingSlot.value = null
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@use './MatchSlotResultView.scss';
+</style>

--- a/src/views/leagues/ScheduleView.scss
+++ b/src/views/leagues/ScheduleView.scss
@@ -383,6 +383,29 @@
   white-space: nowrap;
 }
 
+.btn-slot-result {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 11px;
+  border-radius: 6px;
+  border: 1px solid rgba(99, 179, 237, 0.3);
+  background: rgba(99, 179, 237, 0.07);
+  color: #63b3ed;
+  font-size: 11px;
+  font-weight: 700;
+  font-family: system-ui, sans-serif;
+  cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
+  transition: all 0.13s;
+
+  &:hover {
+    background: rgba(99, 179, 237, 0.14);
+    border-color: rgba(99, 179, 237, 0.55);
+  }
+}
+
 .btn-reveal-entry {
   display: inline-flex;
   align-items: center;

--- a/src/views/leagues/ScheduleView.vue
+++ b/src/views/leagues/ScheduleView.vue
@@ -17,15 +17,6 @@
             <h1 class="page-title page-title--sm">경기 관리</h1>
             <span class="page-subtitle">{{ league?.name }}</span>
           </div>
-          <button
-            class="btn-result"
-            :class="{ 'btn-result--disabled': !rows.length }"
-            :disabled="!rows.length"
-            @click="rows.length && router.push({ name: 'league-match-result', params: { id: leagueId } })"
-          >
-            <AppIcon name="chart" :size="13" />
-            경기 결과 입력
-          </button>
         </div>
 
         <!-- ── 라운드 로빈 자동 생성 ───────────────────────── -->
@@ -130,7 +121,9 @@
                     </template>
                   </VueDatePicker>
                 </div>
-                <span v-if="row.isRevealed" class="badge-revealed">공개됨</span>
+                <button v-if="row.isRevealed" class="badge-revealed">
+                  공개됨
+                </button>
                 <button
                   v-else-if="row.id && bothSubmittedIds.has(row.id)"
                   class="btn-reveal-entry"
@@ -143,6 +136,15 @@
                     <circle cx="7" cy="7" r="1.8" fill="currentColor"/>
                   </svg>
                   {{ revealingId === row.id ? '공개 중...' : '엔트리 공개' }}
+                </button>
+                <button
+                  v-if="row.id"
+                  class="btn-slot-result"
+                  @click="router.push({ name: 'league-match-slot-result', params: { id: leagueId, matchId: row.id } })"
+                  title="결과 입력"
+                >
+                  <AppIcon name="chart" :size="11" />
+                  결과 입력
                 </button>
                 <button class="btn-remove-match" @click="removeMatch(row)">
                   <AppIcon name="close" :size="11" />


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [x] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [ ] 🚨 Hotfix — 긴급 버그 수정

---

## 📌 작업 내용
<!-- 무엇을 했는지 간단히 설명해주세요 -->
- 경기 결과 등록 기능 추가

---

## 🔗 관련 이슈
Close #25 

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- 각 경기 별 결과를 선택할 수 있도록 구현
- 각 팀이 제출한 엔트리의 포인트가 3포인트 이하일 경우 3:3 매치에서 에이스 결정전 승·패여부 선택 가능하도록 구현

---

## 🧪 테스트 방법
- [x] 기능 정상 동작 확인

---

## 📸 스크린샷
<!-- UI 변경이 있다면 첨부해주세요 (선택사항) -->

<img width="922" height="1362" alt="image" src="https://github.com/user-attachments/assets/64542745-5c81-40e9-9c8e-bfb1399cb6cc" />