### PR TITLE
Remove ban info from results modal and add league rankings

### DIFF
--- a/src/components/EntryRevealModal.scss
+++ b/src/components/EntryRevealModal.scss
@@ -416,6 +416,11 @@
 .reveal-ace {
   padding: 12px 0;
   border-top: 1px solid var(--c-border);
+
+  // 티어 밴 행: 센터 컬럼을 넓게
+  .reveal-row:has(.ace-tier-ban-row) {
+    grid-template-columns: 0 1fr 0;
+  }
 }
 
 .ace-ban-col {
@@ -426,6 +431,85 @@
 
   .rse-col--right & {
     align-items: flex-start;
+  }
+}
+
+// 엔트리 확인 — 에이스 티어 밴 전체 표시
+.ace-tier-ban-row {
+  display: flex;
+  gap: 6px;
+  width: max-content;
+}
+
+.ace-tier-ban-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  width: 52px;
+  padding: 10px 6px 8px;
+  border-radius: 10px;
+  position: relative;
+  transition: all 0.15s;
+
+  &--banned {
+    filter: grayscale(0.5) brightness(0.4);
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 10px;
+      background: repeating-linear-gradient(
+        -45deg,
+        transparent,
+        transparent 4px,
+        rgba(0, 0, 0, 0.4) 4px,
+        rgba(0, 0, 0, 0.4) 5px
+      );
+    }
+  }
+}
+
+.ace-tier-ban-letter {
+  font-size: 20px;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.ace-tier-ban-sub {
+  font-size: 9px;
+  font-weight: 600;
+  opacity: 0.75;
+  letter-spacing: 0.3px;
+}
+
+.ace-tier-ban-tags {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  min-height: 14px;
+}
+
+.ace-tier-ban-tag {
+  font-size: 8px;
+  font-weight: 700;
+  padding: 1px 4px;
+  border-radius: 3px;
+  white-space: nowrap;
+  position: relative;
+  z-index: 1;
+
+  &--a {
+    color: #fbbf24;
+    background: rgba(251, 191, 36, 0.2);
+    border: 1px solid rgba(251, 191, 36, 0.4);
+  }
+  &--b {
+    color: #60a5fa;
+    background: rgba(96, 165, 250, 0.2);
+    border: 1px solid rgba(96, 165, 250, 0.4);
   }
 }
 

--- a/src/components/EntryRevealModal.scss
+++ b/src/components/EntryRevealModal.scss
@@ -93,11 +93,33 @@
 }
 
 .reveal-th {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   font-size: 13px;
   font-weight: 800;
-  color: var(--c-text-bright);
+  color: var(--c-text-muted);
+  transition: color 0.15s;
 
-  &--right { text-align: right; }
+  &--right {
+    text-align: right;
+    flex-direction: row-reverse;
+  }
+
+  &--winner {
+    color: #4ade80;
+    font-size: 15px;
+  }
+
+  &--loser {
+    color: var(--c-text-faint);
+    font-weight: 500;
+  }
+}
+
+.reveal-win-crown {
+  font-size: 13px;
+  line-height: 1;
 }
 
 .reveal-th-center {
@@ -477,6 +499,11 @@
   flex-shrink: 0;
 
   &--right { flex-direction: row-reverse; }
+
+  &--winner {
+    .reveal-total-name { color: #4ade80; font-size: 14px; }
+    .reveal-total-pt   { color: #4ade80; font-size: 15px; }
+  }
 }
 
 .reveal-total-name {
@@ -489,4 +516,43 @@
   font-size: 13px;
   font-weight: 800;
   color: #c084fc;
+}
+
+// ── 승점 ─────────────────────────────────────────────────────
+.reveal-match-points {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 8px 16px;
+  border-top: 1px solid var(--c-border-faint);
+  background: var(--c-surface-raised);
+}
+
+.rmp-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--c-text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.rmp-score {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.rmp-a, .rmp-b {
+  font-size: 16px;
+  font-weight: 800;
+  color: var(--c-text-bright);
+  min-width: 20px;
+  text-align: center;
+}
+
+.rmp-sep {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--c-text-faint);
 }

--- a/src/components/EntryRevealModal.vue
+++ b/src/components/EntryRevealModal.vue
@@ -132,38 +132,9 @@
                 </div>
               </div>
 
-              <!-- 밴 정보 영역 (row 아래) -->
-              <div v-if="slotMapRows[slot.num]?.length" class="rse-ban-area">
-                <div v-if="slotMapResults[slot.num].isUndecided" class="rse-undecided">사다리타기로 결정</div>
-                <button
-                  v-if="slotMapResults[slot.num].bannedMapInfo.length"
-                  class="btn-ban-toggle"
-                  @click="toggleBanInfo(slot.num)"
-                >
-                  밴 정보
-                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none" style="transition: transform 0.15s" :style="{ transform: expandedBanSlots.includes(slot.num) ? 'rotate(180deg)' : 'none' }">
-                    <path d="M2 3.5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                </button>
-                <template v-if="expandedBanSlots.includes(slot.num)">
-                  <div class="rse-banned-maps">
-                    <div
-                      v-for="ban in slotMapResults[slot.num].bannedMapInfo"
-                      :key="`ban-${ban.mapId}`"
-                      class="rse-map-item rse-map--banned"
-                    >
-                      <div class="rse-map-thumb-wrap">
-                        <img v-if="getMapInfo(slot.num, ban.mapId)?.thumbnail_url" :src="getMapInfo(slot.num, ban.mapId)!.thumbnail_url!" class="rse-map-thumb" />
-                        <div v-else class="rse-map-thumb-empty" />
-                      </div>
-                      <span class="rse-map-name">{{ getMapInfo(slot.num, ban.mapId)?.name }}</span>
-                      <div class="rse-ban-chips">
-                        <span v-if="ban.byTeamA" class="ban-chip ban-chip--a">{{ teamAName }} 밴</span>
-                        <span v-if="ban.byTeamB" class="ban-chip ban-chip--b">{{ teamBName }} 밴</span>
-                      </div>
-                    </div>
-                  </div>
-                </template>
+              <!-- 사다리타기 안내 -->
+              <div v-if="slotMapRows[slot.num]?.length && slotMapResults[slot.num].isUndecided" class="rse-ban-area">
+                <div class="rse-undecided">사다리타기로 결정</div>
               </div>
             </div>
 
@@ -173,14 +144,9 @@
                 <span class="rsl-num">에이스 결정전</span>
               </div>
 
-              <!-- 티어 밴 행 -->
+              <!-- 에이스 티어 행 -->
               <div class="reveal-row">
-                <div class="rse-col ace-ban-col">
-                  <div v-if="aceTierBanA" class="ace-ban-display">
-                    <span class="ace-ban-label">밴</span>
-                    <span class="ace-ban-tier" :class="`tier-badge--${aceTierBanA.toLowerCase()}`">{{ aceTierBanA }}</span>
-                  </div>
-                </div>
+                <div class="rse-col ace-ban-col"></div>
                 <div class="rse-maps">
                   <div v-if="aceSlotResult?.ace_tier" class="ace-confirmed-tier">
                     <span :class="`tier-badge--${aceSlotResult.ace_tier.toLowerCase()}`" class="ace-tier-chip">{{ aceSlotResult.ace_tier }}</span>
@@ -188,12 +154,7 @@
                   </div>
                   <div v-else class="rse-undecided">티어 사다리타기</div>
                 </div>
-                <div class="rse-col rse-col--right ace-ban-col">
-                  <div v-if="aceTierBanB" class="ace-ban-display ace-ban-display--right">
-                    <span class="ace-ban-tier" :class="`tier-badge--${aceTierBanB.toLowerCase()}`">{{ aceTierBanB }}</span>
-                    <span class="ace-ban-label">밴</span>
-                  </div>
-                </div>
+                <div class="rse-col rse-col--right ace-ban-col"></div>
               </div>
 
               <!-- 선수 & 맵 행 -->

--- a/src/components/EntryRevealModal.vue
+++ b/src/components/EntryRevealModal.vue
@@ -138,9 +138,36 @@
                 </div>
               </div>
 
-              <!-- 사다리타기 안내 -->
-              <div v-if="slotMapRows[slot.num]?.length && slotMapResults[slot.num].isUndecided" class="rse-ban-area">
-                <div class="rse-undecided">사다리타기로 결정</div>
+              <!-- 밴 정보 (엔트리 확인) / 사다리타기 안내 -->
+              <div v-if="slotMapRows[slot.num]?.length" class="rse-ban-area">
+                <div v-if="slotMapResults[slot.num].isUndecided" class="rse-undecided">사다리타기로 결정</div>
+                <template v-if="!showResults && slotMapResults[slot.num].bannedMapInfo.length">
+                  <button class="btn-ban-toggle" @click="toggleBanInfo(slot.num)">
+                    맵 밴 정보
+                    <svg width="10" height="10" viewBox="0 0 10 10" fill="none" style="transition: transform 0.15s" :style="{ transform: expandedBanSlots.includes(slot.num) ? 'rotate(180deg)' : 'none' }">
+                      <path d="M2 3.5l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                  </button>
+                  <template v-if="expandedBanSlots.includes(slot.num)">
+                    <div class="rse-banned-maps">
+                      <div
+                        v-for="ban in slotMapResults[slot.num].bannedMapInfo"
+                        :key="`ban-${ban.mapId}`"
+                        class="rse-map-item rse-map--banned"
+                      >
+                        <div class="rse-map-thumb-wrap">
+                          <img v-if="getMapInfo(slot.num, ban.mapId)?.thumbnail_url" :src="getMapInfo(slot.num, ban.mapId)!.thumbnail_url!" class="rse-map-thumb" />
+                          <div v-else class="rse-map-thumb-empty" />
+                        </div>
+                        <span class="rse-map-name">{{ getMapInfo(slot.num, ban.mapId)?.name }}</span>
+                        <div class="rse-ban-chips">
+                          <span v-if="ban.byTeamA" class="ban-chip ban-chip--a">{{ teamAName }} 밴</span>
+                          <span v-if="ban.byTeamB" class="ban-chip ban-chip--b">{{ teamBName }} 밴</span>
+                        </div>
+                      </div>
+                    </div>
+                  </template>
+                </template>
               </div>
             </div>
 
@@ -154,11 +181,32 @@
               <div class="reveal-row">
                 <div class="rse-col ace-ban-col"></div>
                 <div class="rse-maps">
-                  <div v-if="aceSlotResult?.ace_tier" class="ace-confirmed-tier">
-                    <span :class="`tier-badge--${aceSlotResult.ace_tier.toLowerCase()}`" class="ace-tier-chip">{{ aceSlotResult.ace_tier }}</span>
-                    <span class="ace-tier-sub">에이스 티어</span>
-                  </div>
-                  <div v-else class="rse-undecided">티어 사다리타기</div>
+                  <!-- 엔트리 확인: 전체 티어 밴 표시 -->
+                  <template v-if="!showResults">
+                    <div class="ace-tier-ban-row">
+                      <div
+                        v-for="tier in ALL_TIERS"
+                        :key="tier"
+                        class="ace-tier-ban-btn"
+                        :class="[`tier-badge--${tier.toLowerCase()}`, { 'ace-tier-ban-btn--banned': aceTierBanA === tier || aceTierBanB === tier }]"
+                      >
+                        <span class="ace-tier-ban-letter">{{ tier }}</span>
+                        <span class="ace-tier-ban-sub">티어</span>
+                        <div class="ace-tier-ban-tags">
+                          <span v-if="aceTierBanA === tier" class="ace-tier-ban-tag ace-tier-ban-tag--a">{{ teamAName }} 밴</span>
+                          <span v-if="aceTierBanB === tier" class="ace-tier-ban-tag ace-tier-ban-tag--b">{{ teamBName }} 밴</span>
+                        </div>
+                      </div>
+                    </div>
+                  </template>
+                  <!-- 경기 결과: 확정 티어 or 사다리타기 -->
+                  <template v-else>
+                    <div v-if="aceSlotResult?.ace_tier" class="ace-confirmed-tier">
+                      <span :class="`tier-badge--${aceSlotResult.ace_tier.toLowerCase()}`" class="ace-tier-chip">{{ aceSlotResult.ace_tier }}</span>
+                      <span class="ace-tier-sub">에이스 티어</span>
+                    </div>
+                    <div v-else class="rse-undecided">티어 사다리타기</div>
+                  </template>
                 </div>
                 <div class="rse-col rse-col--right ace-ban-col"></div>
               </div>
@@ -263,6 +311,8 @@ const props = withDefaults(defineProps<{
 }>(), { showResults: false })
 
 defineEmits<{ close: [] }>()
+
+const ALL_TIERS = ['A', 'B', 'C', 'D', 'E'] as const
 
 const SLOT_CONFIG = [
   { num: 1, type: 'individual' },

--- a/src/components/EntryRevealModal.vue
+++ b/src/components/EntryRevealModal.vue
@@ -24,11 +24,17 @@
           <template v-else>
             <!-- 팀 헤더 -->
             <div class="reveal-teams-header">
-              <div class="reveal-th">{{ teamAName }}</div>
+              <div class="reveal-th" :class="showResults && scoreA > scoreB ? 'reveal-th--winner' : showResults && scoreA < scoreB ? 'reveal-th--loser' : ''">
+                {{ teamAName }}
+                <span v-if="showResults && scoreA > scoreB" class="reveal-win-crown">👑</span>
+              </div>
               <div class="reveal-th-center">
                 <span v-if="showResults" class="reveal-score">{{ scoreA }} : {{ scoreB }}</span>
               </div>
-              <div class="reveal-th reveal-th--right">{{ teamBName }}</div>
+              <div class="reveal-th reveal-th--right" :class="showResults && scoreB > scoreA ? 'reveal-th--winner' : showResults && scoreB < scoreA ? 'reveal-th--loser' : ''">
+                <span v-if="showResults && scoreB > scoreA" class="reveal-win-crown">👑</span>
+                {{ teamBName }}
+              </div>
             </div>
 
             <!-- 슬롯별 행 -->
@@ -209,15 +215,24 @@
 
             <!-- 합계 -->
             <div class="reveal-totals">
-              <div class="reveal-total-item">
+              <div class="reveal-total-item" :class="showResults && scoreA > scoreB ? 'reveal-total-item--winner' : ''">
                 <span class="reveal-total-name">{{ teamAName }}</span>
                 <span class="reveal-total-pt">{{ totalPoints(teamACaptainId) }}pt</span>
               </div>
               <div class="reveal-total-sep" />
-              <div class="reveal-total-item reveal-total-item--right">
+              <div class="reveal-total-item reveal-total-item--right" :class="showResults && scoreB > scoreA ? 'reveal-total-item--winner' : ''">
                 <span class="reveal-total-pt">{{ totalPoints(teamBCaptainId) }}pt</span>
                 <span class="reveal-total-name">{{ teamBName }}</span>
               </div>
+            </div>
+            <!-- 승점 -->
+            <div v-if="showResults" class="reveal-match-points">
+              <span class="rmp-label">승점</span>
+              <span class="rmp-score">
+                <span class="rmp-a">{{ matchPointsA }}</span>
+                <span class="rmp-sep">:</span>
+                <span class="rmp-b">{{ matchPointsB }}</span>
+              </span>
             </div>
           </template>
         </div>
@@ -383,6 +398,23 @@ const scoreA = computed(() =>
 const scoreB = computed(() =>
   [...slotWinners.value.values()].filter(w => w === props.teamBCaptainId).length
 )
+
+const MATCH_SLOT_POINTS: Record<number, number> = { 1: 1, 2: 1, 3: 1, 4: 2, 5: 1, 6: 1, 7: 2 }
+
+const matchPointsA = computed(() => {
+  let pts = 0
+  for (const [slot, winner] of slotWinners.value) {
+    if (winner === props.teamACaptainId) pts += MATCH_SLOT_POINTS[slot] ?? 1
+  }
+  return pts
+})
+const matchPointsB = computed(() => {
+  let pts = 0
+  for (const [slot, winner] of slotWinners.value) {
+    if (winner === props.teamBCaptainId) pts += MATCH_SLOT_POINTS[slot] ?? 1
+  }
+  return pts
+})
 
 // ── 밴 로직 ───────────────────────────────────────────────────
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -1,0 +1,22 @@
+import { supabase } from '@/lib/supabase'
+
+export async function notifyEntrySubmitted(params: {
+  leagueName: string
+  teamName: string
+  matchRound: string
+  matchDate: string | null
+}) {
+  try {
+    await supabase.functions.invoke('notify-entry', {
+      body: {
+        leagueName: params.leagueName,
+        teamName: params.teamName,
+        matchRound: params.matchRound,
+        matchDate: params.matchDate,
+        submittedAt: new Date().toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' }),
+      },
+    })
+  } catch {
+    // 알림 실패는 사용자에게 노출하지 않음
+  }
+}

--- a/src/lib/schedules.ts
+++ b/src/lib/schedules.ts
@@ -93,6 +93,16 @@ export async function getSlotResults(scheduleId: number): Promise<SlotResult[]> 
   return data
 }
 
+export async function getSlotResultsForSchedules(scheduleIds: number[]): Promise<SlotResult[]> {
+  if (!scheduleIds.length) return []
+  const { data, error } = await supabase
+    .from('league_match_slot_results')
+    .select('*')
+    .in('schedule_id', scheduleIds)
+  if (error) throw error
+  return data
+}
+
 export async function setSlotResult(
   scheduleId: number,
   slotNum: number,

--- a/src/views/participate/ParticipateView.scss
+++ b/src/views/participate/ParticipateView.scss
@@ -268,6 +268,32 @@
   color: var(--c-text-faint);
 }
 
+.result-team-name {
+  font-size: 13px;
+
+  &--win  { font-weight: 800; color: var(--c-text-bright); }
+  &--loss { font-weight: 400; color: var(--c-text-faint); }
+}
+
+.result-score {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+
+  &--win  { color: #4ade80; }
+  &--loss { color: var(--c-text-faint); }
+}
+
+.result-score-sep {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-text-faint);
+  margin: 0 1px;
+}
+
 .opp-team-name {
   font-size: 13px;
   font-weight: 500;
@@ -317,6 +343,26 @@
   &:hover {
     background: rgba(52, 211, 153, 0.14);
     border-color: rgba(52, 211, 153, 0.55);
+  }
+}
+
+.btn-check-standings {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 7px;
+  border: 1px solid rgba(168, 85, 247, 0.3);
+  background: rgba(168, 85, 247, 0.07);
+  color: #c084fc;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.14s;
+
+  &:hover {
+    background: rgba(168, 85, 247, 0.14);
+    border-color: rgba(168, 85, 247, 0.55);
   }
 }
 
@@ -728,6 +774,163 @@
 
   ul, ol { padding-left: 1.4em; margin: 0.4em 0 0.6em; }
   li     { margin-bottom: 0.2em; }
+}
+
+// ── 경기 결과 순위표 모달 ────────────────────────────────────────
+.modal--result-standings {
+  max-width: 560px;
+}
+
+.standings-body {
+  padding: 8px 4px 12px;
+}
+
+.standings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.standing-team {
+  border-radius: 10px;
+  border: 1px solid var(--c-border);
+  overflow: hidden;
+}
+
+.standing-team-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--c-surface-raised);
+}
+
+.standing-rank {
+  font-size: 13px;
+  font-weight: 800;
+  color: var(--c-text-faint);
+  width: 18px;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.standing-name {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--c-text-bright);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.standing-stats {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.standing-record {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--c-text-muted);
+}
+
+.standing-pts {
+  font-size: 15px;
+  font-weight: 800;
+  color: #fb923c;
+  min-width: 32px;
+  text-align: right;
+}
+
+.standing-pts-label {
+  font-size: 10px;
+  font-weight: 600;
+  margin-left: 1px;
+  opacity: 0.8;
+}
+
+.standing-matches {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--c-border-faint);
+}
+
+.standing-match-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px 8px 44px;
+  border-bottom: 1px solid var(--c-border-faint);
+  transition: background 0.12s;
+
+  &:last-child { border-bottom: none; }
+  &:hover { background: var(--c-overlay); }
+}
+
+.standing-vs {
+  flex: 1;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--c-text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.standing-score {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--c-text-muted);
+  flex-shrink: 0;
+}
+
+.standing-result {
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 4px;
+  flex-shrink: 0;
+
+  &--win  { color: #4ade80; background: rgba(34,197,94,0.12); border: 1px solid rgba(34,197,94,0.25); }
+  &--loss { color: #f87171; background: rgba(239,68,68,0.1);  border: 1px solid rgba(239,68,68,0.22); }
+}
+
+.standing-match-date {
+  font-size: 11px;
+  color: var(--c-text-faint);
+  flex-shrink: 0;
+  min-width: 68px;
+  text-align: right;
+}
+
+.btn-result-view {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(251, 146, 60, 0.35);
+  background: rgba(251, 146, 60, 0.07);
+  color: #fb923c;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.14s;
+
+  &:hover {
+    background: rgba(251, 146, 60, 0.15);
+    border-color: rgba(251, 146, 60, 0.6);
+  }
+}
+
+.standing-no-matches {
+  padding: 8px 16px 8px 44px;
+  font-size: 12px;
+  color: var(--c-text-faint);
+  border-top: 1px solid var(--c-border-faint);
 }
 
 // ── 에이스 결정전 티어 밴 ────────────────────────────────────────

--- a/src/views/participate/ParticipateView.vue
+++ b/src/views/participate/ParticipateView.vue
@@ -523,6 +523,7 @@ import {
   type EntrySlot, type EntryStatus,
 } from '@/lib/entries'
 import { revealEntries } from '@/lib/schedules'
+import { notifyEntrySubmitted } from '@/lib/notifications'
 import { useAuthStore } from '@/stores/auth'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
@@ -1152,6 +1153,16 @@ async function handleSubmitEntry(scheduleId: number) {
   try {
     await submitEntry(scheduleId, myPlayerId.value)
     entryStatusMap.value = new Map(entryStatusMap.value).set(scheduleId, 'submitted')
+
+    const match = matchListModal.matches.find(m => m.schedule.id === scheduleId)
+    if (match) {
+      notifyEntrySubmitted({
+        leagueName: matchListModal.league?.name ?? '',
+        teamName: match.myTeamName,
+        matchRound: `${match.schedule.round}라운드`,
+        matchDate: match.schedule.match_date,
+      })
+    }
   } catch (e: any) {
     alert(e.message ?? '제출 중 오류가 발생했습니다.')
   } finally {

--- a/src/views/participate/ParticipateView.vue
+++ b/src/views/participate/ParticipateView.vue
@@ -72,6 +72,14 @@
               </svg>
               경기 결과
             </button>
+            <button class="btn-check-standings" @click="openStandingsList(league)">
+              <svg width="13" height="13" viewBox="0 0 14 14" fill="none">
+                <rect x="1" y="8" width="3" height="5" rx="1" stroke="currentColor" stroke-width="1.2"/>
+                <rect x="5.5" y="5" width="3" height="8" rx="1" stroke="currentColor" stroke-width="1.2"/>
+                <rect x="10" y="2" width="3" height="11" rx="1" stroke="currentColor" stroke-width="1.2"/>
+              </svg>
+              리그 순위
+            </button>
             <button
               v-if="myCaptainLeagueIds.has(league.id)"
               class="btn-entry-open"
@@ -265,16 +273,67 @@
                 <div class="match-item-info">
                   <span class="round-tag">{{ item.schedule.round }}라운드</span>
                   <span class="match-item-vs">
-                    <span class="my-team-name">{{ item.teamAName }}</span>
-                    <span class="vs-divider">VS</span>
-                    <span class="opp-team-name">{{ item.teamBName }}</span>
+                    <span
+                      class="result-team-name"
+                      :class="item.schedule.winner_captain_id === item.schedule.team_a_captain_id ? 'result-team-name--win' : 'result-team-name--loss'"
+                    >{{ item.teamAName }}</span>
+                    <span class="result-score">
+                      <span :class="item.schedule.winner_captain_id === item.schedule.team_a_captain_id ? 'result-score--win' : 'result-score--loss'">{{ item.teamAWins }}</span>
+                      <span class="result-score-sep">:</span>
+                      <span :class="item.schedule.winner_captain_id === item.schedule.team_b_captain_id ? 'result-score--win' : 'result-score--loss'">{{ item.teamBWins }}</span>
+                    </span>
+                    <span
+                      class="result-team-name"
+                      :class="item.schedule.winner_captain_id === item.schedule.team_b_captain_id ? 'result-team-name--win' : 'result-team-name--loss'"
+                    >{{ item.teamBName }}</span>
                   </span>
                   <span class="match-item-date">
                     {{ item.schedule.match_date ? item.schedule.match_date.replaceAll('-', '/') : '날짜 미정' }}
                   </span>
                 </div>
                 <div class="match-item-actions">
-                  <button class="btn-entry" @click="openResultEntry(item)">확인</button>
+                  <button class="btn-entry" @click="openResultEntry(item)">결과 보기</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- ── 리그 순위 모달 ────────────────────────────────────── -->
+    <Teleport to="body">
+      <div v-if="standingsModal.open" class="modal-overlay">
+        <div class="modal modal--result-standings">
+          <div class="modal-header">
+            <div>
+              <p class="modal-title">리그 순위</p>
+              <p class="modal-subtitle">{{ standingsModal.league?.name }}</p>
+            </div>
+            <button class="modal-close" @click="standingsModal.open = false">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <path d="M2 2l10 10M12 2L2 12" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
+              </svg>
+            </button>
+          </div>
+          <div class="modal-body standings-body">
+            <div v-if="standingsModal.loading" class="state-msg">불러오는 중...</div>
+            <div v-else-if="!standingsModal.standings.length" class="state-msg">
+              아직 종료된 경기가 없습니다.
+            </div>
+            <div v-else class="standings-list">
+              <div
+                v-for="(team, idx) in standingsModal.standings"
+                :key="team.captainId"
+                class="standing-team"
+              >
+                <div class="standing-team-header">
+                  <span class="standing-rank">{{ idx + 1 }}</span>
+                  <span class="standing-name">{{ team.teamName }}</span>
+                  <div class="standing-stats">
+                    <span class="standing-record">{{ team.wins }}승 {{ team.losses }}패</span>
+                    <span class="standing-pts">{{ team.matchPoints }}<span class="standing-pts-label">pt</span></span>
+                  </div>
                 </div>
               </div>
             </div>
@@ -452,7 +511,7 @@ import { getLeagues, getLeagueStatus, type LeagueRow, type LeagueStatus, type El
 import { getCaptains, getMatchMaps } from '@/lib/leagueDetail'
 import { getMaps } from '@/lib/maps'
 import { getDraftPicks, getSwapLog } from '@/lib/draft'
-import { getSchedules, getRevealedSchedules, getCompletedSchedules, type ScheduleRow } from '@/lib/schedules'
+import { getSchedules, getRevealedSchedules, getCompletedSchedules, getSlotResultsForSchedules, type ScheduleRow } from '@/lib/schedules'
 import { getPlayers, getPlayerByDiscordId, type PlayerRow } from '@/lib/players'
 import { getTeamNames } from '@/lib/teamNames'
 import {
@@ -471,6 +530,9 @@ import { Color } from '@tiptap/extension-color'
 import { TextStyle } from '@tiptap/extension-text-style'
 import { TextAlign } from '@tiptap/extension-text-align'
 import { FontSize } from '@/lib/tiptapFontSize'
+
+// 슬롯별 승점
+const MATCH_SLOT_POINTS: Record<number, number> = { 1: 1, 2: 1, 3: 1, 4: 2, 5: 1, 6: 1, 7: 2 }
 
 const SLOT_CONFIG = [
   { num: 1, type: 'individual', count: 1 },
@@ -578,10 +640,42 @@ function openRevealEntry(item: RevealListItem) {
 }
 
 // 종료된 경기 목록 모달
+interface ResultListItem extends RevealListItem {
+  teamAWins: number
+  teamBWins: number
+}
+
 const resultListModal = reactive({
   open: false,
   league: null as LeagueRow | null,
-  matches: [] as RevealListItem[],
+  matches: [] as ResultListItem[],
+  loading: false,
+})
+
+// 리그 순위 모달
+interface MatchResultItem {
+  schedule: ScheduleRow
+  opponentName: string
+  myPoints: number
+  oppPoints: number
+  isWin: boolean
+  teamAName: string
+  teamBName: string
+}
+
+interface TeamStanding {
+  captainId: number
+  teamName: string
+  wins: number
+  losses: number
+  matchPoints: number
+  matches: MatchResultItem[]
+}
+
+const standingsModal = reactive({
+  open: false,
+  league: null as LeagueRow | null,
+  standings: [] as TeamStanding[],
   loading: false,
 })
 
@@ -596,16 +690,120 @@ async function openResultList(league: LeagueRow) {
       getPlayers(),
       getTeamNames(league.id),
     ])
+
     const playerMap = new Map(players.map(p => [p.id, p]))
     const nameMap = new Map(teamNames.map(t => [t.captain_player_id, t.team_name]))
     const teamName = (id: number) => nameMap.get(id) || playerMap.get(id)?.nickname || `선수 ${id}`
-    resultListModal.matches = schedules.map(s => ({
-      schedule: s,
-      teamAName: teamName(s.team_a_captain_id),
-      teamBName: teamName(s.team_b_captain_id),
-    }))
+
+    const slotResults = schedules.length
+      ? await getSlotResultsForSchedules(schedules.map(s => s.id))
+      : []
+
+    const slotsBySchedule = new Map<number, typeof slotResults>()
+    for (const r of slotResults) {
+      if (!slotsBySchedule.has(r.schedule_id)) slotsBySchedule.set(r.schedule_id, [])
+      slotsBySchedule.get(r.schedule_id)!.push(r)
+    }
+
+    resultListModal.matches = schedules
+      .slice()
+      .sort((a, b) => {
+        const da = a.match_date ?? '0000'
+        const db = b.match_date ?? '0000'
+        return da > db ? -1 : da < db ? 1 : b.id - a.id
+      })
+      .map(s => {
+        const slots = slotsBySchedule.get(s.id) ?? []
+        let winsA = 0, winsB = 0
+        for (const slot of slots) {
+          if (slot.winner_captain_id === s.team_a_captain_id) winsA++
+          else if (slot.winner_captain_id === s.team_b_captain_id) winsB++
+        }
+        return {
+          schedule: s,
+          teamAName: teamName(s.team_a_captain_id),
+          teamBName: teamName(s.team_b_captain_id),
+          teamAWins: winsA,
+          teamBWins: winsB,
+        }
+      })
   } finally {
     resultListModal.loading = false
+  }
+}
+
+async function openStandingsList(league: LeagueRow) {
+  standingsModal.open = true
+  standingsModal.league = league
+  standingsModal.standings = []
+  standingsModal.loading = true
+  try {
+    const [schedules, captains, players, teamNames] = await Promise.all([
+      getCompletedSchedules(league.id),
+      getCaptains(league.id),
+      getPlayers(),
+      getTeamNames(league.id),
+    ])
+
+    const playerMap = new Map(players.map(p => [p.id, p]))
+    const nameMap = new Map(teamNames.map(t => [t.captain_player_id, t.team_name]))
+    const teamName = (id: number) => nameMap.get(id) || playerMap.get(id)?.nickname || `선수 ${id}`
+
+    const slotResults = schedules.length
+      ? await getSlotResultsForSchedules(schedules.map(s => s.id))
+      : []
+
+    const slotsBySchedule = new Map<number, typeof slotResults>()
+    for (const r of slotResults) {
+      if (!slotsBySchedule.has(r.schedule_id)) slotsBySchedule.set(r.schedule_id, [])
+      slotsBySchedule.get(r.schedule_id)!.push(r)
+    }
+
+    const standingsMap = new Map<number, TeamStanding>()
+    for (const c of captains) {
+      standingsMap.set(c.player_id, {
+        captainId: c.player_id,
+        teamName: teamName(c.player_id),
+        wins: 0,
+        losses: 0,
+        matchPoints: 0,
+        matches: [],
+      })
+    }
+
+    for (const s of schedules) {
+      const { team_a_captain_id: capA, team_b_captain_id: capB, winner_captain_id: winner } = s
+      const slots = slotsBySchedule.get(s.id) ?? []
+
+      let ptsA = 0, ptsB = 0
+      for (const slot of slots) {
+        const pts = MATCH_SLOT_POINTS[slot.slot_num] ?? 1
+        if (slot.winner_captain_id === capA) ptsA += pts
+        else if (slot.winner_captain_id === capB) ptsB += pts
+      }
+
+      const tNameA = teamName(capA)
+      const tNameB = teamName(capB)
+
+      if (standingsMap.has(capA)) {
+        const st = standingsMap.get(capA)!
+        winner === capA ? st.wins++ : st.losses++
+        st.matchPoints += ptsA
+        st.matches.push({ schedule: s, opponentName: tNameB, myPoints: ptsA, oppPoints: ptsB, isWin: winner === capA, teamAName: tNameA, teamBName: tNameB })
+      }
+      if (standingsMap.has(capB)) {
+        const st = standingsMap.get(capB)!
+        winner === capB ? st.wins++ : st.losses++
+        st.matchPoints += ptsB
+        st.matches.push({ schedule: s, opponentName: tNameA, myPoints: ptsB, oppPoints: ptsA, isWin: winner === capB, teamAName: tNameA, teamBName: tNameB })
+      }
+    }
+
+    standingsModal.standings = [...standingsMap.values()].sort((a, b) =>
+      b.matchPoints !== a.matchPoints ? b.matchPoints - a.matchPoints : b.wins - a.wins
+    )
+  } finally {
+    standingsModal.loading = false
   }
 }
 
@@ -617,6 +815,15 @@ const resultModal = reactive({
 
 function openResultEntry(item: RevealListItem) {
   resultModal.item = item
+  resultModal.open = true
+}
+
+function openStandingResult(match: MatchResultItem) {
+  resultModal.item = {
+    schedule: match.schedule,
+    teamAName: match.teamAName,
+    teamBName: match.teamBName,
+  }
   resultModal.open = true
 }
 

--- a/src/views/participate/ParticipateView.vue
+++ b/src/views/participate/ParticipateView.vue
@@ -819,15 +819,6 @@ function openResultEntry(item: RevealListItem) {
   resultModal.open = true
 }
 
-function openStandingResult(match: MatchResultItem) {
-  resultModal.item = {
-    schedule: match.schedule,
-    teamAName: match.teamAName,
-    teamBName: match.teamBName,
-  }
-  resultModal.open = true
-}
-
 // 엔트리 모달
 const loadingEntry = ref(false)
 const entrySaving = ref(false)


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [x] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [ ] 🚨 Hotfix — 긴급 버그 수정

---

## 📌 작업 내용
<!-- 무엇을 했는지 간단히 설명해주세요 -->
- 경기 결과 모달 페이지에서 과도한 정보 정리
- 리그 팀 순위 확인할 수 있는 모달 추가
- 엔트리 확인 단계에서 정보 제공 확대
- 엔트리 제출시 디스코드 알람 동작

---

## 🧪 테스트 방법
- [x] 기능 정상 동작 확인
- [ ] 예외 케이스 테스트