### PR TITLE
Fix calendar prediction modal layout and size adjustments

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -82,7 +82,7 @@ export interface CalendarItem {
   round?: number
 }
 
-function matchTypeLabel(type: string, round: number): string {
+export function matchTypeLabel(type: string, round: number): string {
   if (type === 'regular') return `${round}R`
   if (type === 'semifinal') return '4강'
   if (type === 'final_set1') return '결승 1세트'

--- a/src/views/home/HomeCalendar.scss
+++ b/src/views/home/HomeCalendar.scss
@@ -222,13 +222,16 @@
 }
 
 .cal-modal {
-  width: 420px;
+  width: 560px;
   max-width: 100%;
+  max-height: calc(100vh - 32px);
   background: var(--c-surface-raised);
   border: 1px solid var(--c-border-strong);
   border-radius: 14px;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
   animation: modalIn 0.2s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
@@ -274,6 +277,9 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 .cal-detail-item {
@@ -294,7 +300,7 @@
 
 .cal-detail-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
 }
 
@@ -306,6 +312,8 @@
   font-size: 11px;
   font-weight: 600;
   color: white;
+  flex-shrink: 0;
+  margin-top: 2px;
 }
 
 .cal-detail-time {
@@ -329,6 +337,24 @@
   font-size: 16px;
   font-weight: 700;
   color: var(--c-text-bright);
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+  line-height: 1.4;
+}
+
+.cal-detail-heading-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.cal-detail-league {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--c-text-sub);
+  letter-spacing: 0.02em;
 }
 
 .cal-detail-meta {
@@ -478,6 +504,7 @@
 
 .pred-team {
   flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -530,9 +557,10 @@
   font-weight: 700;
   color: var(--c-text-bright);
   max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  text-align: center;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
 }
 
 .pred-pct {

--- a/src/views/home/HomeCalendar.vue
+++ b/src/views/home/HomeCalendar.vue
@@ -89,7 +89,15 @@
                 <span class="cal-detail-tag" :style="{ background: EVENT_TYPE_META[detailEvent.event_type].color }">
                   {{ EVENT_TYPE_META[detailEvent.event_type].label }}
                 </span>
-                <h4 class="cal-detail-heading">{{ detailEvent.title }}</h4>
+                <div class="cal-detail-heading-wrap">
+                  <template v-if="detailEvent.source === 'schedule' && detailEvent.league_name">
+                    <span class="cal-detail-league">{{ detailEvent.league_name }}</span>
+                    <h4 class="cal-detail-heading">
+                      {{ matchTypeLabel(detailEvent.match_type ?? '', detailEvent.round ?? 0) }}: {{ detailEvent.team_a_name }} vs {{ detailEvent.team_b_name }}
+                    </h4>
+                  </template>
+                  <h4 v-else class="cal-detail-heading">{{ detailEvent.title }}</h4>
+                </div>
               </div>
               <div class="cal-detail-meta">
                 <span>{{ detailEvent.event_date }}</span>
@@ -188,7 +196,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, computed, onMounted } from 'vue'
-import { getCalendarItems, EVENT_TYPE_META, type CalendarItem } from '@/lib/events'
+import { getCalendarItems, EVENT_TYPE_META, matchTypeLabel, type CalendarItem } from '@/lib/events'
 import {
   getMatchForPrediction,
   placePrediction,


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [x] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [ ] 🚨 Hotfix — 긴급 버그 수정

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- 일정 상세 모달에서 리그 경기인 경우 리그명을 1행, "라운드: A vs B"를 2행으로 분리 표시
- 모달 폭 420px → 560px 로 확장, body 영역에 overflow scroll 추가하여 긴 컨텐츠 대응
- 팀 버튼 내 팀명을 ellipsis 대신 줄바꿈으로 변경하여 긴 팀명도 잘리지 않게 표시