### PR TITLE
feat: 팀 구성 모달 팀원 정렬 (티어 → 종족 → 닉네임)

### DIFF
--- a/src/views/participate/ParticipateView.vue
+++ b/src/views/participate/ParticipateView.vue
@@ -185,7 +185,7 @@
                   <span class="roster-nick">{{ team.viceCaptain.nickname }}</span>
                 </div>
                 <div
-                  v-for="m in team.members.filter(x => x.id !== team.viceCaptain?.id)"
+                  v-for="m in team.members"
                   :key="m.id"
                   class="roster-member"
                 >
@@ -751,6 +751,9 @@ const rosterModal = reactive({
   teams: [] as RosterTeam[],
 })
 
+const ROSTER_TIER_RANK: Record<string, number> = { A: 5, B: 4, C: 3, D: 2, E: 1 }
+const ROSTER_RACE_RANK: Record<string, number> = { T: 3, Z: 2, P: 1 }
+
 async function openRosterList(league: LeagueRow) {
   rosterModal.open = true
   rosterModal.league = league
@@ -774,12 +777,18 @@ async function openRosterList(league: LeagueRow) {
       .map(c => {
         const captain = playerMap.get(c.player_id)
         const roster = rosters.get(c.player_id) ?? []
-        const memberIds = roster.filter(id => id !== c.player_id)
+        const tn = tnMap.get(c.player_id)
+        const viceId = tn?.vice_captain_player_id ?? null
+        // 팀원: 팀장 본인 + 부팀장 제외, 티어 내림차순(A→E) → 종족(T→Z→P) → 닉네임 정렬
+        const memberIds = roster.filter(id => id !== c.player_id && id !== viceId)
         const members = memberIds
           .map(id => playerMap.get(id))
           .filter((x): x is PlayerRow => Boolean(x))
-        const tn = tnMap.get(c.player_id)
-        const viceId = tn?.vice_captain_player_id ?? null
+          .sort((a, b) =>
+            (ROSTER_TIER_RANK[b.tier] ?? 0) - (ROSTER_TIER_RANK[a.tier] ?? 0)
+            || (ROSTER_RACE_RANK[b.race] ?? 0) - (ROSTER_RACE_RANK[a.race] ?? 0)
+            || a.nickname.localeCompare(b.nickname),
+          )
         const viceP = viceId ? playerMap.get(viceId) : null
         return {
           captainId: c.player_id,


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [x] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [ ] 🚨 Hotfix — 긴급 버그 수정

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- 팀장 / 부팀장은 상단 고정, 나머지 팀원은 티어 내림차순(A→E)
- 티어 내에서는 종족 순(T→Z→P), 종족 내에서는 닉네임 순으로 정렬
- 부팀장은 데이터 레이어에서 팀원 목록에서 제외하므로 템플릿 필터 제거