### PR TITLE
feat: 인앱 알림 시스템 + 예측 결과 알림

### DIFF
--- a/src/components/AppHeader.scss
+++ b/src/components/AppHeader.scss
@@ -156,3 +156,180 @@
     color: var(--c-text-2);
   }
 }
+
+// ── 알림 ───────────────────────────────────────────────
+.notif-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.notif-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--c-border-strong);
+  background: var(--c-overlay);
+  color: var(--c-text-sub);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--c-text-bright);
+    border-color: var(--c-brand-border);
+  }
+  &--active {
+    color: var(--c-brand-text);
+    border-color: var(--c-brand-border);
+    background: var(--c-brand-bg-soft);
+  }
+}
+
+.notif-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--c-danger, #f87171);
+  color: white;
+  font-size: 10px;
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  letter-spacing: -0.02em;
+  border: 1.5px solid var(--c-bg, #0a0b10);
+  font-variant-numeric: tabular-nums;
+}
+
+.notif-pop {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 340px;
+  max-height: 480px;
+  border-radius: 12px;
+  border: 1px solid var(--c-border-strong);
+  background: var(--c-surface);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 200;
+  animation: notifPop 0.18s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes notifPop {
+  from { opacity: 0; transform: translateY(-4px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.notif-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.notif-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--c-text-bright);
+}
+
+.notif-mark-all {
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--c-border-strong);
+  background: transparent;
+  color: var(--c-text-sub);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--c-text-bright);
+    border-color: var(--c-brand-border);
+  }
+}
+
+.notif-state {
+  padding: 28px 16px;
+  text-align: center;
+  color: var(--c-text-muted);
+  font-size: 12px;
+}
+
+.notif-list {
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.notif-item {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 11px 14px;
+  border: none;
+  border-bottom: 1px solid var(--c-border-faint);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  position: relative;
+  transition: background 0.15s;
+
+  &:last-child { border-bottom: none; }
+  &:hover { background: var(--c-overlay); }
+
+  &--unread {
+    background: var(--c-brand-bg-soft);
+    &::before {
+      content: '';
+      position: absolute;
+      left: 6px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: var(--c-brand);
+    }
+    .notif-item-title { color: var(--c-text-bright); }
+  }
+
+  &--prediction_win .notif-item-title { color: var(--c-success, #4ade80); }
+  &--prediction_loss .notif-item-title { color: var(--c-danger, #f87171); }
+  &--prediction_refund .notif-item-title { color: var(--c-brand-text); }
+}
+
+.notif-item-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--c-text);
+  padding-left: 6px;
+}
+
+.notif-item-body {
+  font-size: 11px;
+  color: var(--c-text-sub);
+  line-height: 1.5;
+  padding-left: 6px;
+}
+
+.notif-item-time {
+  font-size: 10px;
+  color: var(--c-text-muted);
+  font-weight: 600;
+  padding-left: 6px;
+}

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -48,6 +48,37 @@
         <span class="user-name">{{ displayName }}</span>
       </div>
 
+      <!-- 알림 -->
+      <div v-if="auth.user && myUserId !== null" class="notif-wrap" ref="notifRef">
+        <button class="notif-btn" :class="{ 'notif-btn--active': notifOpen }" @click="toggleNotif" title="알림">
+          <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+            <path d="M9 2v1.2M4.5 14.5h9l-1.2-1.5V8.5a3.3 3.3 0 10-6.6 0V13l-1.2 1.5zM7 16a2 2 0 004 0" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span v-if="unreadCount > 0" class="notif-badge">{{ unreadCount > 99 ? '99+' : unreadCount }}</span>
+        </button>
+        <div v-if="notifOpen" class="notif-pop">
+          <div class="notif-head">
+            <span class="notif-title">알림</span>
+            <button v-if="unreadCount > 0" class="notif-mark-all" @click="handleMarkAll">모두 읽음</button>
+          </div>
+          <div v-if="notifLoading" class="notif-state">불러오는 중...</div>
+          <div v-else-if="!notifs.length" class="notif-state">알림이 없습니다.</div>
+          <div v-else class="notif-list">
+            <button
+              v-for="n in notifs"
+              :key="n.id"
+              class="notif-item"
+              :class="{ 'notif-item--unread': !n.is_read, [`notif-item--${n.type}`]: true }"
+              @click="handleNotifClick(n)"
+            >
+              <span class="notif-item-title">{{ n.title }}</span>
+              <span v-if="n.body" class="notif-item-body">{{ n.body }}</span>
+              <span class="notif-item-time">{{ formatRelTime(n.created_at) }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
       <!-- 액션 버튼 슬롯 (페이지별로 다른 버튼 주입 가능) -->
       <slot name="actions" />
 
@@ -71,16 +102,22 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useTheme } from '@/composables/useTheme'
+import { getPlayerByDiscordId } from '@/lib/players'
+import {
+  getNotifications,
+  getUnreadCount,
+  markNotificationRead,
+  markAllRead,
+  type NotificationRow,
+} from '@/lib/notifications'
 
 const auth = useAuthStore()
 const router = useRouter()
 const { theme, toggle, init } = useTheme()
-
-onMounted(init)
 
 // 추후 네비게이션 항목 여기에 추가
 const navItems: { to: string; label: string }[] = [
@@ -95,6 +132,103 @@ async function handleLogout() {
   await auth.logout()
   router.push({ name: 'login' })
 }
+
+// ── 알림 ───────────────────────────────────────────────
+const myUserId = ref<number | null>(null)
+const notifOpen = ref(false)
+const notifLoading = ref(false)
+const notifs = ref<NotificationRow[]>([])
+const unreadCount = ref(0)
+const notifRef = ref<HTMLElement | null>(null)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+async function resolveMyUserId() {
+  const discordId = auth.user?.identities?.find(i => i.provider === 'discord')?.id ?? ''
+  if (!discordId) return
+  try {
+    const me = await getPlayerByDiscordId(discordId)
+    if (me) myUserId.value = me.id
+  } catch {}
+}
+
+async function refreshUnread() {
+  if (myUserId.value === null) return
+  try {
+    unreadCount.value = await getUnreadCount(myUserId.value)
+  } catch {}
+}
+
+async function loadNotifs() {
+  if (myUserId.value === null) return
+  notifLoading.value = true
+  try {
+    notifs.value = await getNotifications(myUserId.value, 20)
+  } finally {
+    notifLoading.value = false
+  }
+}
+
+async function toggleNotif() {
+  if (notifOpen.value) {
+    notifOpen.value = false
+    return
+  }
+  notifOpen.value = true
+  await loadNotifs()
+}
+
+async function handleNotifClick(n: NotificationRow) {
+  if (!n.is_read) {
+    try {
+      await markNotificationRead(n.id)
+      n.is_read = true
+      unreadCount.value = Math.max(0, unreadCount.value - 1)
+    } catch {}
+  }
+}
+
+async function handleMarkAll() {
+  if (myUserId.value === null) return
+  await markAllRead(myUserId.value)
+  notifs.value.forEach(n => { n.is_read = true })
+  unreadCount.value = 0
+}
+
+function onDocClick(e: MouseEvent) {
+  if (!notifOpen.value) return
+  if (notifRef.value && !notifRef.value.contains(e.target as Node)) {
+    notifOpen.value = false
+  }
+}
+
+function formatRelTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const m = Math.floor(diff / 60000)
+  if (m < 1) return '방금 전'
+  if (m < 60) return `${m}분 전`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}시간 전`
+  const d = Math.floor(h / 24)
+  if (d < 7) return `${d}일 전`
+  const date = new Date(iso)
+  return `${date.getMonth() + 1}/${date.getDate()}`
+}
+
+onMounted(() => {
+  init()
+  resolveMyUserId().then(() => {
+    refreshUnread()
+    pollTimer = setInterval(refreshUnread, 30000)
+  })
+  document.addEventListener('click', onDocClick)
+})
+
+watch(() => auth.user?.id, () => { resolveMyUserId().then(refreshUnread) })
+
+onBeforeUnmount(() => {
+  if (pollTimer) clearInterval(pollTimer)
+  document.removeEventListener('click', onDocClick)
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -20,3 +20,59 @@ export async function notifyEntrySubmitted(params: {
     // 알림 실패는 사용자에게 노출하지 않음
   }
 }
+
+// ── In-app 알림 ───────────────────────────────────────────────
+export type NotificationType =
+  | 'prediction_win'
+  | 'prediction_loss'
+  | 'prediction_refund'
+  | string
+
+export interface NotificationRow {
+  id: number
+  user_id: number
+  type: NotificationType
+  title: string
+  body: string | null
+  is_read: boolean
+  metadata: Record<string, unknown> | null
+  created_at: string
+}
+
+export async function getNotifications(userId: number, limit = 20): Promise<NotificationRow[]> {
+  const { data, error } = await supabase
+    .from('notifications')
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(limit)
+  if (error) throw error
+  return data ?? []
+}
+
+export async function getUnreadCount(userId: number): Promise<number> {
+  const { count, error } = await supabase
+    .from('notifications')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .eq('is_read', false)
+  if (error) throw error
+  return count ?? 0
+}
+
+export async function markNotificationRead(id: number): Promise<void> {
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('id', id)
+  if (error) throw error
+}
+
+export async function markAllRead(userId: number): Promise<void> {
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('user_id', userId)
+    .eq('is_read', false)
+  if (error) throw error
+}


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [x] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [ ] 🚨 Hotfix — 긴급 버그 수정

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- DB: notifications 테이블 신규 생성 (user_id, type, title, body, is_read, metadata, created_at)
- apply_prediction_result 트리거 확장: 베팅 결과 정산 시점에 알림 자동 생성 (적중/실패/환불 3종)
- prediction_win: 적중 시 순이익 표시
- prediction_loss: 실패 시 베팅 손실액 표시
- prediction_refund: 적중자 0명 환불 케이스
- 이미 정산된 예측의 재계산은 중복 알림 생성 안 함
- AppHeader: 닉네임 옆에 종 모양 알림 버튼 + 미읽음 뱃지, 클릭 시 최근
- 20개 알림 팝오버. 모두 읽음 버튼, 외부 클릭으로 닫힘.
- 30초 폴링으로 미읽음 카운트 갱신