### PR TITLE
feat: 팀전 엔트리에서 랜덤 종족 출전 선택 지원

### DIFF
--- a/src/components/EntryRevealModal.scss
+++ b/src/components/EntryRevealModal.scss
@@ -671,3 +671,11 @@
   font-weight: 700;
   color: var(--c-text-faint);
 }
+
+// 팀전 랜덤 종족 배지
+.rse-race--random {
+  background: var(--c-brand-bg);
+  border: 1px solid var(--c-brand-border);
+  color: var(--c-brand-text);
+  font-weight: 800;
+}

--- a/src/components/EntryRevealModal.vue
+++ b/src/components/EntryRevealModal.vue
@@ -60,7 +60,8 @@
                           class="rse-player"
                         >
                           <span class="rse-pt">{{ playerPt(pid) }}pt</span>
-                          <span class="rse-race" :class="`race-badge--${playerRace(pid).toLowerCase()}`">{{ playerRace(pid) }}</span>
+                          <span v-if="isRandomPlayer(teamACaptainId, slot.num, pid)" class="rse-race rse-race--random">R</span>
+                          <span v-else class="rse-race" :class="`race-badge--${playerRace(pid).toLowerCase()}`">{{ playerRace(pid) }}</span>
                           <span class="rse-name-badge" :class="`tier-badge--${playerTier(pid).toLowerCase()}`">{{ playerName(pid) }}</span>
                         </div>
                       </div>
@@ -114,7 +115,8 @@
                           class="rse-player"
                         >
                           <span class="rse-name-badge" :class="`tier-badge--${playerTier(pid).toLowerCase()}`">{{ playerName(pid) }}</span>
-                          <span class="rse-race" :class="`race-badge--${playerRace(pid).toLowerCase()}`">{{ playerRace(pid) }}</span>
+                          <span v-if="isRandomPlayer(teamBCaptainId, slot.num, pid)" class="rse-race rse-race--random">R</span>
+                          <span v-else class="rse-race" :class="`race-badge--${playerRace(pid).toLowerCase()}`">{{ playerRace(pid) }}</span>
                           <span class="rse-pt">{{ playerPt(pid) }}pt</span>
                         </div>
                       </div>
@@ -431,6 +433,11 @@ function getEntry(captainId: number, slotNum: number): EntryRecord | undefined {
 
 function getSlotPlayerIds(captainId: number, slotNum: number): number[] {
   return getEntry(captainId, slotNum)?.player_ids ?? []
+}
+
+function isRandomPlayer(captainId: number, slotNum: number, pid: number): boolean {
+  const e = getEntry(captainId, slotNum)
+  return !!e?.random_player_ids?.includes(pid)
 }
 
 function getBan(captainId: number, slotNum: number): string | null {

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -15,6 +15,8 @@ export interface EntrySlot {
   player_ids: number[]
   banned_map_id?: string | null
   picked_map_id?: string | null
+  // 팀전(4경기) 한정: 랜덤 종족으로 출전하는 선수 id 목록
+  random_player_ids?: number[]
 }
 
 /** 밴 선택이 필요한 경기 슬롯 번호 */
@@ -27,6 +29,7 @@ export interface EntryRecord {
   player_ids: number[]
   banned_map_id: string | null
   picked_map_id: string | null
+  random_player_ids: number[]
 }
 
 // ── DB CRUD ─────────────────────────────────────────────────
@@ -36,7 +39,7 @@ export async function getEntries(
 ): Promise<EntrySlot[]> {
   const { data, error } = await supabase
     .from('league_match_entries')
-    .select('match_slot, player_ids, banned_map_id, picked_map_id')
+    .select('match_slot, player_ids, banned_map_id, picked_map_id, random_player_ids')
     .eq('schedule_id', scheduleId)
     .eq('captain_player_id', captainPlayerId)
     .order('match_slot', { ascending: true })
@@ -65,6 +68,7 @@ export async function saveEntries(
     player_ids: s.player_ids,
     banned_map_id: s.banned_map_id ?? null,
     picked_map_id: s.picked_map_id ?? null,
+    random_player_ids: s.random_player_ids ?? [],
     updated_at: new Date().toISOString(),
   }))
   const { error } = await supabase.from('league_match_entries').insert(rows)
@@ -156,7 +160,7 @@ export async function getEntriesForSchedules(scheduleIds: number[]): Promise<(En
   if (!scheduleIds.length) return []
   const { data, error } = await supabase
     .from('league_match_entries')
-    .select('schedule_id, captain_player_id, match_slot, player_ids, banned_map_id, picked_map_id')
+    .select('schedule_id, captain_player_id, match_slot, player_ids, banned_map_id, picked_map_id, random_player_ids')
     .in('schedule_id', scheduleIds)
   if (error) throw error
   return (data ?? []) as (EntryRecord & { schedule_id: number })[]
@@ -166,7 +170,7 @@ export async function getEntriesForSchedules(scheduleIds: number[]): Promise<(En
 export async function getScheduleEntries(scheduleId: number): Promise<EntryRecord[]> {
   const { data, error } = await supabase
     .from('league_match_entries')
-    .select('captain_player_id, match_slot, player_ids, banned_map_id, picked_map_id')
+    .select('captain_player_id, match_slot, player_ids, banned_map_id, picked_map_id, random_player_ids')
     .eq('schedule_id', scheduleId)
     .order('captain_player_id', { ascending: true })
     .order('match_slot', { ascending: true })

--- a/src/views/leagues/MatchSlotResultView.scss
+++ b/src/views/leagues/MatchSlotResultView.scss
@@ -914,3 +914,11 @@
   }
 }
 
+
+// 팀전 랜덤 종족 배지
+.slot-race--random {
+  background: var(--c-brand-bg);
+  border: 1px solid var(--c-brand-border);
+  color: var(--c-brand-text);
+  font-weight: 800;
+}

--- a/src/views/leagues/MatchSlotResultView.vue
+++ b/src/views/leagues/MatchSlotResultView.vue
@@ -1268,7 +1268,7 @@ onMounted(async () => {
     const finalRosters = computeFinalRosters(captains, draftPicks, swapLog)
     const makeRoster = (captainId: number): SlotPlayerInfo[] => {
       const memberIds = finalRosters.get(captainId) ?? []
-      return memberIds.map(toInfo)
+      return memberIds.map(id => toInfo(id, undefined))
     }
     rosterA.value = makeRoster(match.team_a_captain_id)
     rosterB.value = makeRoster(match.team_b_captain_id)

--- a/src/views/leagues/MatchSlotResultView.vue
+++ b/src/views/leagues/MatchSlotResultView.vue
@@ -77,7 +77,8 @@
                 <div class="slot-players">
                   <template v-if="slotPlayerMap.get(slot.num)?.teamA?.length">
                     <div v-for="(p, idx) in getActivePlayers(slot.num, true)" :key="p.id" class="slot-player-row">
-                      <span v-if="p.race" class="slot-race" :class="`race-badge--${p.race.toLowerCase()}`">{{ p.race.toUpperCase() }}</span>
+                      <span v-if="p.isRandom" class="slot-race slot-race--random">R</span>
+                      <span v-else-if="p.race" class="slot-race" :class="`race-badge--${p.race.toLowerCase()}`">{{ p.race.toUpperCase() }}</span>
                       <span class="slot-player-name" :class="`tier-badge--${p.tier.toLowerCase()}`">{{ p.nickname }}</span>
                       <span v-if="isSubstituted(slot.num, true, idx)" class="sub-badge">대체</span>
                     </div>
@@ -123,7 +124,8 @@
                     <div v-for="(p, idx) in getActivePlayers(slot.num, false)" :key="p.id" class="slot-player-row slot-player-row--right">
                       <span v-if="isSubstituted(slot.num, false, idx)" class="sub-badge">대체</span>
                       <span class="slot-player-name" :class="`tier-badge--${p.tier.toLowerCase()}`">{{ p.nickname }}</span>
-                      <span v-if="p.race" class="slot-race" :class="`race-badge--${p.race.toLowerCase()}`">{{ p.race.toUpperCase() }}</span>
+                      <span v-if="p.isRandom" class="slot-race slot-race--random">R</span>
+                      <span v-else-if="p.race" class="slot-race" :class="`race-badge--${p.race.toLowerCase()}`">{{ p.race.toUpperCase() }}</span>
                     </div>
                   </template>
                   <span v-else class="slot-team-name" :class="`tier-badge--${teamB?.tier.toLowerCase()}`">
@@ -482,7 +484,7 @@ interface TeamInfo {
   tier: string
 }
 
-interface SlotPlayerInfo { id: number; nickname: string; tier: string; race: string }
+interface SlotPlayerInfo { id: number; nickname: string; tier: string; race: string; isRandom?: boolean }
 interface SlotPlayers { teamA: SlotPlayerInfo[]; teamB: SlotPlayerInfo[] }
 interface MapInfo { id: string; name: string; thumbnail_url: string | null }
 interface SlotMapState {
@@ -1147,9 +1149,15 @@ onMounted(async () => {
     slotWinners.value = winnerMap
 
     // 슬롯별 선수 맵
-    const toInfo = (id: number): SlotPlayerInfo => {
+    const toInfo = (id: number, randoms: number[] | undefined): SlotPlayerInfo => {
       const p = playerMap.get(id)
-      return { id, nickname: p?.nickname ?? `선수${id}`, tier: p?.tier ?? 'e', race: p?.race ?? '' }
+      return {
+        id,
+        nickname: p?.nickname ?? `선수${id}`,
+        tier: p?.tier ?? 'e',
+        race: p?.race ?? '',
+        isRandom: randoms?.includes(id) ?? false,
+      }
     }
     const aEntries = entries.filter(e => e.captain_player_id === match.team_a_captain_id)
     const bEntries = entries.filter(e => e.captain_player_id === match.team_b_captain_id)
@@ -1159,8 +1167,8 @@ onMounted(async () => {
       const aSlot = aEntries.find(e => e.match_slot === slotNum)
       const bSlot = bEntries.find(e => e.match_slot === slotNum)
       spMap.set(slotNum, {
-        teamA: (aSlot?.player_ids ?? []).map(toInfo),
-        teamB: (bSlot?.player_ids ?? []).map(toInfo),
+        teamA: (aSlot?.player_ids ?? []).map(id => toInfo(id, aSlot?.random_player_ids)),
+        teamB: (bSlot?.player_ids ?? []).map(id => toInfo(id, bSlot?.random_player_ids)),
       })
     }
     slotPlayerMap.value = spMap

--- a/src/views/participate/ParticipateView.scss
+++ b/src/views/participate/ParticipateView.scss
@@ -1089,3 +1089,72 @@
   flex: 1;
   min-width: 0;
 }
+
+// ── 팀전 랜덤 종족 토글 ───────────────────────────────────
+.slot-select-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+
+  > :first-child { flex: 1; min-width: 0; }
+}
+
+.random-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 9px 4px 7px;
+  border-radius: 7px;
+  border: 1px solid var(--c-border-strong);
+  background: var(--c-overlay);
+  color: var(--c-text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+  flex-shrink: 0;
+  transition: all 0.15s;
+
+  &:hover {
+    color: var(--c-text-bright);
+    border-color: var(--c-brand-border);
+  }
+
+  &--on {
+    background: var(--c-brand-bg);
+    border-color: var(--c-brand);
+    color: var(--c-brand-text);
+    box-shadow: 0 0 0 2px var(--c-brand-bg-soft);
+
+    .random-toggle-letter { background: var(--c-brand); color: white; }
+  }
+}
+
+.random-toggle-letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--c-border-strong);
+  color: var(--c-text-2);
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.random-toggle-label { letter-spacing: 0.02em; }
+
+.random-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 6px;
+  background: var(--c-brand-bg);
+  border: 1px solid var(--c-brand-border);
+  color: var(--c-brand-text);
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+}

--- a/src/views/participate/ParticipateView.vue
+++ b/src/views/participate/ParticipateView.vue
@@ -571,14 +571,37 @@
 
                       <!-- 선수 선택 -->
                       <div class="slot-selects">
-                        <PlayerSelect
+                        <div
                           v-for="idx in slot.count"
                           :key="idx"
-                          :model-value="getSlotPlayer(slot.num, idx - 1)"
-                          :options="buildOptions(slot.num, idx - 1)"
-                          :disabled="entryModal.readonly"
-                          @update:model-value="setSlotPlayer(slot.num, idx - 1, $event)"
-                        />
+                          class="slot-select-row"
+                          :class="{ 'slot-select-row--team': slot.type === 'team' }"
+                        >
+                          <PlayerSelect
+                            :model-value="getSlotPlayer(slot.num, idx - 1)"
+                            :options="buildOptions(slot.num, idx - 1)"
+                            :disabled="entryModal.readonly"
+                            @update:model-value="setSlotPlayer(slot.num, idx - 1, $event)"
+                          />
+                          <!-- 팀전 한정: 랜덤 출전 토글 -->
+                          <template v-if="slot.type === 'team' && getSlotPlayer(slot.num, idx - 1)">
+                            <button
+                              v-if="!entryModal.readonly"
+                              type="button"
+                              class="random-toggle"
+                              :class="{ 'random-toggle--on': entryModal.randomIds.has(getSlotPlayer(slot.num, idx - 1)) }"
+                              :title="entryModal.randomIds.has(getSlotPlayer(slot.num, idx - 1)) ? '랜덤 출전 해제' : '랜덤 종족으로 출전'"
+                              @click="toggleRandomRace(getSlotPlayer(slot.num, idx - 1))"
+                            >
+                              <span class="random-toggle-letter">R</span>
+                              <span class="random-toggle-label">랜덤</span>
+                            </button>
+                            <span
+                              v-else-if="entryModal.randomIds.has(getSlotPlayer(slot.num, idx - 1))"
+                              class="random-badge"
+                            >랜덤</span>
+                          </template>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -1123,6 +1146,8 @@ interface EntryModalState {
   banSelections: Record<number, string | null>
   pickSelections: Record<number, string | null>
   aceTierBan: string | null
+  /** 팀전(4경기) 한정: 랜덤 종족으로 출전하는 player id 집합 */
+  randomIds: Set<number>
   soloMax: number
   teamMax: number
   totalMax: number
@@ -1139,6 +1164,7 @@ const entryModal = reactive<EntryModalState>({
   banSelections: {},
   pickSelections: {},
   aceTierBan: null,
+  randomIds: new Set<number>(),
   soloMax: 16,
   teamMax: 7,
   totalMax: 23,
@@ -1323,6 +1349,7 @@ async function openEntryModal(item: MyMatchItem, readonly = false) {
   entryModal.banSelections = {}
   entryModal.pickSelections = {}
   entryModal.aceTierBan = null
+  entryModal.randomIds = new Set<number>()
   entryModal.soloMax = item.soloMax
   entryModal.teamMax = item.teamMax
   entryModal.totalMax = item.totalMax
@@ -1378,6 +1405,9 @@ async function openEntryModal(item: MyMatchItem, readonly = false) {
         if (e.picked_map_id && (BAN_SLOTS as readonly number[]).includes(e.match_slot)) {
           entryModal.pickSelections[e.match_slot] = e.picked_map_id
         }
+        if (e.match_slot === TEAM_SLOT && e.random_player_ids) {
+          for (const id of e.random_player_ids) entryModal.randomIds.add(id)
+        }
       }
     }
     entryModal.aceTierBan = existingAceBan
@@ -1400,6 +1430,12 @@ function toggleBan(slotNum: number, mapId: string) {
 function togglePick(slotNum: number, mapId: string) {
   if (entryModal.banSelections[slotNum] === mapId) return
   entryModal.pickSelections[slotNum] = entryModal.pickSelections[slotNum] === mapId ? null : mapId
+}
+
+function toggleRandomRace(playerId: number) {
+  if (!playerId) return
+  if (entryModal.randomIds.has(playerId)) entryModal.randomIds.delete(playerId)
+  else entryModal.randomIds.add(playerId)
 }
 
 async function handleEntrySubmit() {
@@ -1447,12 +1483,17 @@ async function handleEntrySubmit() {
 
   entrySaving.value = true
   try {
-    const slots: EntrySlot[] = SLOT_CONFIG.map(slot => ({
-      match_slot: slot.num,
-      player_ids: entryModal.selections[slot.num].filter(Boolean),
-      banned_map_id: entryModal.banSelections[slot.num] ?? null,
-      picked_map_id: (BAN_SLOTS as readonly number[]).includes(slot.num) ? (entryModal.pickSelections[slot.num] ?? null) : null,
-    }))
+    const slots: EntrySlot[] = SLOT_CONFIG.map(slot => {
+      const player_ids = entryModal.selections[slot.num].filter(Boolean)
+      const isTeam = slot.num === TEAM_SLOT
+      return {
+        match_slot: slot.num,
+        player_ids,
+        banned_map_id: entryModal.banSelections[slot.num] ?? null,
+        picked_map_id: (BAN_SLOTS as readonly number[]).includes(slot.num) ? (entryModal.pickSelections[slot.num] ?? null) : null,
+        random_player_ids: isTeam ? player_ids.filter(id => entryModal.randomIds.has(id)) : [],
+      }
+    })
     await Promise.all([
       saveEntries(entryModal.schedule!.id, myPlayerId.value!, slots),
       saveAceTierBan(entryModal.schedule!.id, myPlayerId.value!, entryModal.aceTierBan),


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [x] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [ ] 🚨 Hotfix — 긴급 버그 수정

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- 팀전(4경기)은 주종족이 아닌 랜덤으로 출전하는 경우가 있어, 엔트리 제출 시 선수별로 "랜덤 출전" 토글을 추가.
- 팀전 슬롯 한정으로 PlayerSelect 옆에 "R 랜덤" 토글 버튼