### PR TITLE
fix: 경기 결과 모달이 슬롯 결과의 대체 선수 반영

### DIFF
--- a/src/components/EntryRevealModal.scss
+++ b/src/components/EntryRevealModal.scss
@@ -671,3 +671,17 @@
   font-weight: 700;
   color: var(--c-text-faint);
 }
+
+// 대체 출전 배지
+.rse-sub-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(168, 85, 247, 0.15);
+  border: 1px solid rgba(168, 85, 247, 0.4);
+  color: #c084fc;
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}

--- a/src/components/EntryRevealModal.vue
+++ b/src/components/EntryRevealModal.vue
@@ -55,13 +55,14 @@
                     <div class="rse-team-group">
                       <div class="rse-players">
                         <div
-                          v-for="pid in getSlotPlayerIds(teamACaptainId, slot.num)"
-                          :key="pid"
+                          v-for="(pid, pidIdx) in getSlotPlayerIds(teamACaptainId, slot.num)"
+                          :key="pidIdx"
                           class="rse-player"
                         >
                           <span class="rse-pt">{{ playerPt(pid) }}pt</span>
                           <span class="rse-race" :class="`race-badge--${playerRace(pid).toLowerCase()}`">{{ playerRace(pid) }}</span>
                           <span class="rse-name-badge" :class="`tier-badge--${playerTier(pid).toLowerCase()}`">{{ playerName(pid) }}</span>
+                          <span v-if="isSubstituted(teamACaptainId, slot.num, pidIdx)" class="rse-sub-badge">대체</span>
                         </div>
                       </div>
                       <span v-if="showResults && slotWinner(slot.num) === teamACaptainId" class="rse-win-badge">WIN</span>
@@ -109,10 +110,11 @@
                       <span v-if="showResults && slotWinner(slot.num) === teamBCaptainId" class="rse-win-badge">WIN</span>
                       <div class="rse-players">
                         <div
-                          v-for="pid in getSlotPlayerIds(teamBCaptainId, slot.num)"
-                          :key="pid"
+                          v-for="(pid, pidIdx) in getSlotPlayerIds(teamBCaptainId, slot.num)"
+                          :key="pidIdx"
                           class="rse-player"
                         >
+                          <span v-if="isSubstituted(teamBCaptainId, slot.num, pidIdx)" class="rse-sub-badge">대체</span>
                           <span class="rse-name-badge" :class="`tier-badge--${playerTier(pid).toLowerCase()}`">{{ playerName(pid) }}</span>
                           <span class="rse-race" :class="`race-badge--${playerRace(pid).toLowerCase()}`">{{ playerRace(pid) }}</span>
                           <span class="rse-pt">{{ playerPt(pid) }}pt</span>
@@ -361,6 +363,8 @@ const slotMapRows = ref<Record<number, MapInfo[]>>({})
 const slotWinners = ref(new Map<number, number>())
 // showResults 모드에서 사다리타기로 확정된 맵 (slot_num → map_id)
 const slotSelectedMaps = ref(new Map<number, string>())
+// 슬롯별 선수 대체 정보 (slot_num → { teamA, teamB } — 각 배열은 원본 인덱스 순서)
+const slotSubs = ref(new Map<number, { teamA: number[] | null; teamB: number[] | null }>())
 
 // 에이스 결정전
 const aceSlotResult = ref<SlotResult | null>(null)
@@ -410,13 +414,18 @@ onMounted(async () => {
     if (slotResultsData.length) {
       const wm = new Map<number, number>()
       const sm = new Map<number, string>()
+      const subs = new Map<number, { teamA: number[] | null; teamB: number[] | null }>()
       for (const r of slotResultsData) {
         if (r.winner_captain_id != null) wm.set(r.slot_num, r.winner_captain_id)
         if (r.selected_map_id) sm.set(r.slot_num, r.selected_map_id)
         if (r.slot_num === 7) aceSlotResult.value = r
+        if (r.sub_player_a_ids || r.sub_player_b_ids) {
+          subs.set(r.slot_num, { teamA: r.sub_player_a_ids, teamB: r.sub_player_b_ids })
+        }
       }
       slotWinners.value = wm
       slotSelectedMaps.value = sm
+      slotSubs.value = subs
     }
   } catch (e: any) {
     loadError.value = e.message ?? '데이터를 불러올 수 없습니다.'
@@ -430,7 +439,22 @@ function getEntry(captainId: number, slotNum: number): EntryRecord | undefined {
 }
 
 function getSlotPlayerIds(captainId: number, slotNum: number): number[] {
-  return getEntry(captainId, slotNum)?.player_ids ?? []
+  const original = getEntry(captainId, slotNum)?.player_ids ?? []
+  const sub = slotSubs.value.get(slotNum)
+  if (!sub) return original
+  const isTeamA = captainId === props.teamACaptainId
+  const subIds = isTeamA ? sub.teamA : sub.teamB
+  return subIds && subIds.length ? subIds : original
+}
+
+function isSubstituted(captainId: number, slotNum: number, idx: number): boolean {
+  const sub = slotSubs.value.get(slotNum)
+  if (!sub) return false
+  const original = getEntry(captainId, slotNum)?.player_ids ?? []
+  const isTeamA = captainId === props.teamACaptainId
+  const subIds = isTeamA ? sub.teamA : sub.teamB
+  if (!subIds) return false
+  return subIds[idx] != null && subIds[idx] !== original[idx]
 }
 
 function getBan(captainId: number, slotNum: number): string | null {


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [ ] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [x] 🚨 Hotfix — 긴급 버그 수정

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- EntryRevealModal 이 league_match_slot_results.sub_player_a_ids / sub_player_b_ids 를 무시한 채 원본 player_ids 만 보여줘서 운영 중 적용된 대체가 화면에 반영되지 않던 문제 수정