### PR TITLE
fix: 승부예측 랭킹 정렬 기준을 표시되는 점수와 동일하게 변경

### DIFF
--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -358,5 +358,5 @@ export async function getRankings(): Promise<RankingRow[]> {
       accuracy: a.resolved > 0 ? (a.correct / a.resolved) * 100 : 0,
     })
   }
-  return rows.sort((a, b) => b.current_points - a.current_points || b.accuracy - a.accuracy || a.nickname.localeCompare(b.nickname))
+  return rows.sort((a, b) => b.total_points - a.total_points || b.accuracy - a.accuracy || a.nickname.localeCompare(b.nickname))
 }


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [ ] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [x] 🚨 Hotfix — 긴급 버그 수정

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- 랭킹 정렬 로직 수정