### PR TITLE
fix: 승부예측 랭킹에서 결과 미확정 배팅만 있는 유저 제외

### DIFF
--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -344,7 +344,7 @@ export async function getRankings(): Promise<RankingRow[]> {
   const rows: RankingRow[] = []
   for (const u of users ?? []) {
     const a = agg.get(u.id)
-    if (!a) continue
+    if (!a || a.resolved === 0) continue
     rows.push({
       user_id: u.id,
       nickname: u.nickname,


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [ ] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [x] 🚨 Hotfix — 긴급 버그 수정

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- resolved_count가 0인 유저(배팅은 했으나 아직 경기 결과가 없는 경우)를 랭킹 목록에서 노출하지 않도록 필터 조건 추가