### PR TITLE
Implement military discount feature for player points

### DIFF
--- a/src/components/PlayerSelect.scss
+++ b/src/components/PlayerSelect.scss
@@ -128,3 +128,15 @@
   margin-left: auto;
   opacity: 0.8;
 }
+
+.ps-opt-military {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  line-height: 1.4;
+}

--- a/src/components/PlayerSelect.vue
+++ b/src/components/PlayerSelect.vue
@@ -13,7 +13,8 @@
       <template v-if="selectedOpt?.tier">
         <span class="ps-sel-race" v-if="selectedOpt.race" :class="`race-badge--${selectedOpt.race.toLowerCase()}`">{{ selectedOpt.race }}</span>
         <span class="ps-label">{{ selectedOpt.label }}</span>
-        <span class="ps-sel-pts" v-if="selectedOpt.points">{{ selectedOpt.points }}pt</span>
+        <span v-if="selectedOpt.is_military" class="ps-opt-military">군</span>
+        <span class="ps-sel-pts" v-if="selectedOpt.points !== undefined">{{ selectedOpt.points }}pt</span>
       </template>
       <span v-else class="ps-label">{{ selectedLabel }}</span>
       <svg class="ps-arrow" width="10" height="10" viewBox="0 0 10 10" fill="none">
@@ -45,6 +46,7 @@
           <template v-if="opt.tier">
             <span class="ps-opt-race" v-if="opt.race" :class="`race-badge--${opt.race.toLowerCase()}`">{{ opt.race }}</span>
             <span class="ps-opt-name" :class="`tier-color--${opt.tier.toLowerCase()}`">{{ opt.label }}</span>
+            <span v-if="opt.is_military" class="ps-opt-military">군</span>
             <span class="ps-opt-pts" :class="`tier-color--${opt.tier.toLowerCase()}`">{{ opt.points }}pt</span>
           </template>
           <template v-else>{{ opt.label }}</template>
@@ -64,6 +66,7 @@ export interface SelectOption {
   race?: string
   points?: number
   disabled?: boolean
+  is_military?: boolean
 }
 
 const props = defineProps<{

--- a/src/lib/players.ts
+++ b/src/lib/players.ts
@@ -9,6 +9,7 @@ export interface PlayerRow {
   race: 'T' | 'Z' | 'P'
   tier: string
   is_admin: boolean
+  is_military: boolean
   created_at: string
   updated_at: string
 }
@@ -34,7 +35,7 @@ export async function getPlayerByDiscordId(discordId: string): Promise<PlayerRow
 
 export async function updatePlayer(
   id: number,
-  fields: { nickname: string; aliases: string[]; star_nicknames: string[]; race: 'T' | 'Z' | 'P'; tier: string },
+  fields: { nickname: string; aliases: string[]; star_nicknames: string[]; race: 'T' | 'Z' | 'P'; tier: string; is_military: boolean },
 ): Promise<PlayerRow> {
   const { data, error } = await supabase
     .from('users')

--- a/src/views/games/GamesView.vue
+++ b/src/views/games/GamesView.vue
@@ -246,6 +246,7 @@ async function handleLink(player: PlayerRow) {
       star_nicknames: newStarNicknames,
       race: player.race,
       tier: player.tier,
+      is_military: player.is_military,
     })
     // 로컬 players 업데이트
     const idx = players.value.findIndex(p => p.id === player.id)

--- a/src/views/participate/ParticipateView.vue
+++ b/src/views/participate/ParticipateView.vue
@@ -1313,13 +1313,17 @@ function buildOptions(slotNum: number, idx: number): SelectOption[] {
       }
     })
     .sort((a, b) => (TIER_POINTS[b.tier] ?? 0) - (TIER_POINTS[a.tier] ?? 0))
-    .map(m => ({
-      value: m.id,
-      label: m.nickname,
-      tier: m.tier,
-      race: m.race,
-      points: TIER_POINTS[m.tier] ?? 0,
-    }))
+    .map(m => {
+      const base = TIER_POINTS[m.tier] ?? 0
+      return {
+        value: m.id,
+        label: m.nickname,
+        tier: m.tier,
+        race: m.race,
+        points: m.is_military ? Math.max(0, base - 1) : base,
+        is_military: m.is_military,
+      }
+    })
 }
 
 const playerTierMap = computed(() => {
@@ -1328,15 +1332,26 @@ const playerTierMap = computed(() => {
   return m
 })
 
+const playerMilitaryMap = computed(() => {
+  const m = new Map<number, boolean>()
+  for (const p of entryModal.teamMembers) m.set(p.id, p.is_military ?? false)
+  return m
+})
+
+function effectivePoints(playerId: number): number {
+  const base = TIER_POINTS[playerTierMap.value.get(playerId) ?? ''] ?? 0
+  return playerMilitaryMap.value.get(playerId) ? Math.max(0, base - 1) : base
+}
+
 const individualPoints = computed(() =>
   (INDIVIDUAL_SLOTS as readonly number[]).reduce((sum, slotNum) => {
     const id = entryModal.selections[slotNum]?.[0] ?? 0
-    return sum + (id ? TIER_POINTS[playerTierMap.value.get(id) ?? ''] ?? 0 : 0)
+    return sum + (id ? effectivePoints(id) : 0)
   }, 0)
 )
 const teamPoints = computed(() =>
   (entryModal.selections[TEAM_SLOT] ?? []).reduce((sum, id) =>
-    sum + (id ? TIER_POINTS[playerTierMap.value.get(id) ?? ''] ?? 0 : 0), 0)
+    sum + (id ? effectivePoints(id) : 0), 0)
 )
 const totalPoints = computed(() => individualPoints.value + teamPoints.value)
 

--- a/src/views/players/PlayersView.scss
+++ b/src/views/players/PlayersView.scss
@@ -212,4 +212,43 @@
   &--p.active { border-color: var(--race-p-border); background: var(--race-p-bg); color: var(--race-p); }
 }
 
+// ── 군인 신분 ─────────────────────────────────────────────
+.td-military { text-align: center; }
+
+.military-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 5px;
+  font-size: 11px;
+  font-weight: 700;
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+
+  &--none {
+    background: transparent;
+    color: var(--c-text-muted);
+    border-color: transparent;
+  }
+}
+
+.military-toggle {
+  padding: 7px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--c-border-strong);
+  background: var(--c-overlay);
+  color: var(--c-text-sub);
+  font-size: 13px;
+  font-weight: 600;
+  font-family: system-ui, sans-serif;
+  cursor: pointer;
+  transition: all 0.15s;
+
+  &--on {
+    border-color: rgba(59, 130, 246, 0.5);
+    background: rgba(59, 130, 246, 0.1);
+    color: #60a5fa;
+  }
+}
+
 // ── 모달 푸터 / 버튼 (공통: _buttons.scss, _modal.scss via _page.scss)

--- a/src/views/players/PlayersView.vue
+++ b/src/views/players/PlayersView.vue
@@ -44,6 +44,7 @@
             <th>스타 닉네임</th>
             <th>종족</th>
             <th>티어</th>
+            <th>군인</th>
             <th></th>
           </tr>
         </thead>
@@ -91,6 +92,10 @@
             </td>
             <td>
               <span class="tier-badge" :class="`tier-badge--${player.tier.toLowerCase()}`">{{ player.tier }}</span>
+            </td>
+            <td class="td-military">
+              <span v-if="player.is_military" class="military-badge">군인</span>
+              <span v-else class="military-badge military-badge--none">-</span>
             </td>
             <td class="td-action">
               <button class="edit-btn" @click="openEdit(player)">수정</button>
@@ -209,6 +214,19 @@
                 </button>
               </div>
             </div>
+
+            <!-- 군인 신분 -->
+            <div class="field">
+              <label class="field-label">군인 신분</label>
+              <button
+                type="button"
+                class="military-toggle"
+                :class="{ 'military-toggle--on': form.is_military }"
+                @click="form.is_military = !form.is_military"
+              >
+                {{ form.is_military ? '군인 (엔트리 -1pt)' : '일반' }}
+              </button>
+            </div>
           </div>
 
           <div class="modal-footer">
@@ -291,7 +309,7 @@ onUnmounted(() => {
 
 // ── 수정 모달 ─────────────────────────────────────────────
 const editTarget = ref<PlayerRow | null>(null)
-const form = reactive({ nickname: '', aliases: [] as string[], star_nicknames: [] as string[], race: 'T' as 'T' | 'Z' | 'P', tier: '' })
+const form = reactive({ nickname: '', aliases: [] as string[], star_nicknames: [] as string[], race: 'T' as 'T' | 'Z' | 'P', tier: '', is_military: false })
 const aliasInput = ref('')
 const starNicknameInput = ref('')
 const saving = ref(false)
@@ -324,6 +342,7 @@ function openEdit(player: PlayerRow) {
   form.star_nicknames = [...player.star_nicknames]
   form.race = player.race
   form.tier = player.tier
+  form.is_military = player.is_military
   aliasInput.value = ''
   starNicknameInput.value = ''
   saveError.value = null
@@ -349,6 +368,7 @@ async function handleSave() {
       star_nicknames: form.star_nicknames,
       race: form.race,
       tier: form.tier.trim(),
+      is_military: form.is_military,
     })
     const idx = players.value.findIndex(p => p.id === updated.id)
     if (idx !== -1) players.value[idx] = updated


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [x] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [ ] 🚨 Hotfix — 긴급 버그 수정

---

## 🧩 변경 사항
<!-- 주요 변경 내용을 적어주세요 -->
- users.is_military 컬럼 추가 (dev/prod)
- 선수 관리 화면에서 군인 신분 토글 가능 (테이블 + 수정 모달)
- 엔트리 선택 시 군인 선수의 포인트를 -1 적용 (최소 0)
- PlayerSelect 드롭다운에 군인 여부 시각적 표시(군 뱃지)
