### PR TITLE
fix: 부팀장 엔트리 저장 시 팀장 ID로 기록되도록 수정

### DIFF
--- a/src/views/participate/ParticipateView.vue
+++ b/src/views/participate/ParticipateView.vue
@@ -1141,6 +1141,8 @@ interface EntryModalState {
   readonly: boolean
   schedule: ScheduleRow | null
   leagueId: string
+  /** 엔트리를 저장/제출할 대상 팀의 팀장 player_id (부팀장이 대신 제출해도 이 값으로 기록) */
+  captainPlayerId: number
   opponentTeamName: string
   teamMembers: PlayerRow[]
   selections: Record<number, number[]>
@@ -1159,6 +1161,7 @@ const entryModal = reactive<EntryModalState>({
   readonly: false,
   schedule: null,
   leagueId: '',
+  captainPlayerId: 0,
   opponentTeamName: '',
   teamMembers: [],
   selections: {},
@@ -1360,6 +1363,7 @@ async function openEntryModal(item: MyMatchItem, readonly = false) {
   entryModal.readonly = readonly
   entryModal.schedule = item.schedule
   entryModal.leagueId = item.leagueId
+  entryModal.captainPlayerId = item.myTeamCaptainId
   entryModal.opponentTeamName = item.opponentTeamName
   entryModal.teamMembers = []
   entryModal.slotMaps = {}
@@ -1512,8 +1516,8 @@ async function handleEntrySubmit() {
       }
     })
     await Promise.all([
-      saveEntries(entryModal.schedule!.id, myPlayerId.value!, slots),
-      saveAceTierBan(entryModal.schedule!.id, myPlayerId.value!, entryModal.aceTierBan),
+      saveEntries(entryModal.schedule!.id, entryModal.captainPlayerId, slots),
+      saveAceTierBan(entryModal.schedule!.id, entryModal.captainPlayerId, entryModal.aceTierBan),
     ])
     entryStatusMap.value.set(entryModal.schedule!.id, 'saved')
     // 경기 목록 모달의 상태도 갱신


### PR DESCRIPTION
## PR 타입
<!-- 해당하는 항목에 x를 채워주세요 -->
- [ ] ✨ Feature — 새로운 기능
- [ ] 🧹 Refactor — 코드 개선 / 구조 변경
- [x] 🚨 Hotfix — 긴급 버그 수정

---
부팀장이 엔트리를 저장할 때 saveEntries/saveAceTierBan에 로그인 본인 player_id(myPlayerId)를 넘겨, 엔트리가 실제 팀장이 아닌 부팀장 ID로 기록되던 버그를 수정한다. 조회·제출·공개동의·집계는 모두 팀장 ID(item.myTeamCaptainId)를 사용하는데 저장만 어긋나, 부팀장이 낸 엔트리가 팀장 기준 조회/집계에 잡히지 않고 사실상 미제출 처리되었다.

entryModal에 captainPlayerId를 두고 openEntryModal에서 item.myTeamCaptainId로 채운 뒤, 저장 시 이 값을 사용하도록 통일했다.